### PR TITLE
Harden MLB Phase 1.5 hit-rate projections and calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Aggregate backtest metrics:
 .venv/bin/python scripts/backtest_mlb_fantasy_projections.py --predictions /tmp/mlb_backtest_rows.csv --output /tmp/mlb_backtest_scores.csv
 ```
 
+Phase 1.5 quality controls (under `adapters.mlb_projection_phase15`) support:
+- regular-season + terminal-PA cleaning (`data_cleaning.*`)
+- count consistency constraints (`modeling.count_nonnegative_constraints`, `modeling.hits_leq_pa_constraint`)
+- count-derived `hit_rate` uncertainty draws (`modeling.hit_rate_uncertainty_draws`)
+- model-family anti-churn selection threshold (`modeling.selection_min_delta_mae`)
+- hit-rate calibration controls (`uncertainty.hit_rate_residual_scale_*`, `uncertainty.coverage_target`, `uncertainty.min_bucket_residual_count`)
+
 ## Documentation Map
 
 Core docs:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Force retrain before inference:
 .venv/bin/pytest -q
 ```
 
+### 4) Fantasy MLB Phase 1.5 Helpers
+
+Build snapshot dataset:
+
+```bash
+.venv/bin/python scripts/build_mlb_batter_projection_dataset.py --input tests/testdata/fantasy/mlb_batter_games_phase1.csv --output /tmp/mlb_phase15_snapshots.csv --metric hits
+```
+
+Aggregate backtest metrics:
+
+```bash
+.venv/bin/python scripts/backtest_mlb_fantasy_projections.py --predictions /tmp/mlb_backtest_rows.csv --output /tmp/mlb_backtest_scores.csv
+```
+
 ## Documentation Map
 
 Core docs:

--- a/config/fantasy/mlb_phase15_projection_2026.yaml
+++ b/config/fantasy/mlb_phase15_projection_2026.yaml
@@ -1,0 +1,91 @@
+contest:
+  contest_id: ud-mlb-2026-phase15-projections
+  provider: underdog
+  sport: mlb
+  mode: season_long_tournament
+  scoring_ruleset_id: ud_mlb_classic
+  mode_config:
+    roster:
+      slots: 18
+    advancement:
+      rounds: [12, 2]
+    payouts:
+      first: 100000
+  metadata:
+    season: 2026
+
+metrics:
+  base_metrics:
+    - metric_id: plate_appearances
+      horizon: season
+      adapter_key: mlb_plate_appearances_season
+    - metric_id: hits
+      horizon: season
+      adapter_key: mlb_hits_season
+    - metric_id: total_bases
+      horizon: season
+      adapter_key: mlb_total_bases_season
+    - metric_id: walks
+      horizon: season
+      adapter_key: mlb_walks_season
+    - metric_id: strikeouts
+      horizon: season
+      adapter_key: mlb_strikeouts_season
+    - metric_id: pa_vs_lhp
+      horizon: season
+      adapter_key: mlb_pa_vs_lhp_season
+    - metric_id: pa_vs_rhp
+      horizon: season
+      adapter_key: mlb_pa_vs_rhp_season
+    - metric_id: hard_hit_events
+      horizon: season
+      adapter_key: mlb_hard_hit_events_season
+    - metric_id: hit_rate
+      horizon: season
+      adapter_key: mlb_hit_rate_season
+    - metric_id: walk_rate
+      horizon: season
+      adapter_key: mlb_walk_rate_season
+    - metric_id: strikeout_rate
+      horizon: season
+      adapter_key: mlb_strikeout_rate_season
+    - metric_id: slugging_proxy
+      horizon: season
+      adapter_key: mlb_slugging_proxy_season
+
+mapping:
+  player_id_map_path: data/fantasy/mlb_player_mapping_2026.csv
+  unresolved_policy: warn
+
+markets:
+  mode: season_long_tournament
+  definitions:
+    - market_id: ud_mlb_2026_hits
+      metric_id: hits
+      horizon: season
+      window_start: "2026-03-01"
+      window_end: "2026-10-01"
+
+adapters:
+  mlb_projection_phase15:
+    input_dataset_path: data/mlb/reusable_batter_games_2026.csv
+    entity_id_col: batter
+    date_col: game_date
+    seed: 2026
+    min_history_games: 20
+    model_name: xgboost
+    train_end_date: "2025-12-31"
+    inference_anchor_date: "2026-08-01"
+    snapshot_anchor_frequency: weekly
+    snapshot_min_games: 5
+    model_selection_enabled: false
+    model_selection_candidates: [poisson, elastic_net, hist_gradient_boosting, xgboost]
+    model_selection_primary_metric: mae
+    model_selection_max_trials_per_model: 1
+    pybaseball_priors_enabled: false
+    pybaseball_priors_cache_path: data/processed/fantasy/mlb_batter_priors.parquet
+    pybaseball_priors_seasons: [2021, 2022, 2023, 2024, 2025]
+    pybaseball_priors_refresh: false
+    uncertainty_method: empirical_quantiles
+    uncertainty_residual_bucket_col: season_to_date_pa
+    uncertainty_bucket_edges: [0, 100, 250, 450, 700]

--- a/config/fantasy/mlb_phase15_projection_2026.yaml
+++ b/config/fantasy/mlb_phase15_projection_2026.yaml
@@ -89,3 +89,20 @@ adapters:
     uncertainty_method: empirical_quantiles
     uncertainty_residual_bucket_col: season_to_date_pa
     uncertainty_bucket_edges: [0, 100, 250, 450, 700]
+    data_cleaning:
+      regular_season_only: true
+      require_batter_pa_dedup: true
+    modeling:
+      count_nonnegative_constraints: true
+      hits_leq_pa_constraint: true
+      hit_rate_derivation_source: counts_only
+      hit_rate_uncertainty_draws: 500
+      selection_min_delta_mae: 0.0
+    uncertainty:
+      hit_rate_residual_scale_global: 1.0
+      hit_rate_residual_scale_by_bucket: {}
+      coverage_target: 0.8
+      calibration_objective: coverage_width_tradeoff
+      min_bucket_residual_count: 100
+    evaluation:
+      primary_metric_focus: hit_rate

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,8 @@ Modules:
 - `src/fantasy/adapters/mlb/backtest.py`: walk-forward fold generation and MAE/RMSE/bias aggregation
 
 Runtime semantics:
-1. count metrics remain directly modeled
-2. rate metrics are derived from modeled count outputs
-3. uncertainty remains empirical and contract-stable (`p10/p50/p90/stddev`)
+1. `hits` and `plate_appearances` use cleaned regular-season batter-game inputs and snapshot/rest-of-season labels
+2. `hit_rate` is derived from constrained count outputs (`hits`, `plate_appearances`)
+3. uncertainty is sampled from count residual banks and transformed to bounded rate intervals with configurable residual scaling and sparse-bucket fallback
+4. output contract remains stable (`p10/p50/p90/stddev` + provenance fields)
+5. optional model-family selection can switch off default model only when MAE gain clears configured anti-churn threshold

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,3 +134,19 @@ Modeling path:
 2. build leakage-safe training/inference slices by date cutoffs
 3. reuse `src/mlb/models/trainers.py` (`fit_estimator`, `predict_estimator`)
 4. emit neutral projection rows with uncertainty and provenance fields
+
+## Fantasy Phase 1.5 Architecture
+
+Phase 1.5 extends MLB adapter quality controls while preserving the same registry
+surface and output schema.
+
+Modules:
+- `src/fantasy/adapters/mlb/datasets.py`: player-season anchor snapshots and rest-of-season labels
+- `src/fantasy/adapters/mlb/feature_engineering.py`: shifted rolling, playing-time stability, and leakage guards
+- `src/fantasy/adapters/mlb/priors.py`: pybaseball prior-table cache load and deterministic fallback joins
+- `src/fantasy/adapters/mlb/backtest.py`: walk-forward fold generation and MAE/RMSE/bias aggregation
+
+Runtime semantics:
+1. count metrics remain directly modeled
+2. rate metrics are derived from modeled count outputs
+3. uncertainty remains empirical and contract-stable (`p10/p50/p90/stddev`)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -199,3 +199,26 @@ Phase 1 base metrics (`horizon = season`):
 - `walk_rate`
 - `strikeout_rate`
 - `slugging_proxy`
+
+## Fantasy MLB Projection Adapter Schema (Phase 1.5)
+
+Reference config:
+- `config/fantasy/mlb_phase15_projection_2026.yaml`
+
+Optional adapter section:
+- `adapters.mlb_projection_phase15`
+
+Additional supported keys beyond Phase 1:
+- `training_data_paths`
+- `snapshot_anchor_frequency` (default: `weekly`)
+- `snapshot_min_games` (default: `5`)
+- `model_selection_enabled` (default: `false`)
+- `model_selection_candidates`
+- `model_selection_primary_metric` (default: `mae`)
+- `model_selection_max_trials_per_model` (default: `1`)
+- `pybaseball_priors_enabled` (default: `false`)
+- `pybaseball_priors_cache_path`
+- `pybaseball_priors_seasons`
+- `pybaseball_priors_refresh` (default: `false`)
+- `uncertainty_residual_bucket_col` (default: `season_to_date_pa`)
+- `uncertainty_bucket_edges` (default: `[0, 100, 250, 450, 700]`)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -216,9 +216,24 @@ Additional supported keys beyond Phase 1:
 - `model_selection_candidates`
 - `model_selection_primary_metric` (default: `mae`)
 - `model_selection_max_trials_per_model` (default: `1`)
+- `modeling.selection_min_delta_mae` (default: `0.0`)
 - `pybaseball_priors_enabled` (default: `false`)
 - `pybaseball_priors_cache_path`
 - `pybaseball_priors_seasons`
 - `pybaseball_priors_refresh` (default: `false`)
 - `uncertainty_residual_bucket_col` (default: `season_to_date_pa`)
 - `uncertainty_bucket_edges` (default: `[0, 100, 250, 450, 700]`)
+- `uncertainty.hit_rate_residual_scale_global` (default: `1.0`)
+- `uncertainty.hit_rate_residual_scale_by_bucket` (default: `{}`)
+- `uncertainty.coverage_target` (default: `0.80`)
+- `uncertainty.calibration_objective` (default: `coverage_width_tradeoff`)
+- `uncertainty.min_bucket_residual_count` (default: `100`)
+
+Nested quality controls:
+- `data_cleaning.regular_season_only` (default: `true`)
+- `data_cleaning.require_batter_pa_dedup` (default: `true`)
+- `modeling.count_nonnegative_constraints` (default: `true`)
+- `modeling.hits_leq_pa_constraint` (default: `true`)
+- `modeling.hit_rate_derivation_source` (default: `counts_only`)
+- `modeling.hit_rate_uncertainty_draws` (default: `500`)
+- `evaluation.primary_metric_focus` (default: `hit_rate`)

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -203,6 +203,10 @@ Additional modules:
 
 Phase 1.5 policy:
 - Train count-like targets directly and derive rate metrics from predicted counts.
+- For `hits` and `plate_appearances`, use snapshot/rest-of-season labels from cleaned regular-season batter-game views.
 - Keep neutral output schema unchanged.
 - Use leakage-safe shifted rolling features for snapshot construction.
+- Enforce nonnegative count projections and `hits <= plate_appearances` consistency before deriving `hit_rate`.
 - Keep pybaseball priors optional with cache-first/offline fallbacks.
+- Support model-family anti-churn selection (`modeling.selection_min_delta_mae`) using MAE/RMSE/abs-bias tie-breaks.
+- Support hit-rate interval calibration via residual scaling and sparse-bucket fallback controls.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -192,3 +192,17 @@ Phase 1 policy:
 - Output remains in-memory only.
 - Schema is neutral and contains no MLB-specific columns.
 - Uncertainty defaults to empirical residual quantiles.
+
+## Fantasy Phase 1.5 MLB Projection Hardening
+
+Additional modules:
+- `src/fantasy/adapters/mlb/datasets.py`
+- `src/fantasy/adapters/mlb/feature_engineering.py`
+- `src/fantasy/adapters/mlb/priors.py`
+- `src/fantasy/adapters/mlb/backtest.py`
+
+Phase 1.5 policy:
+- Train count-like targets directly and derive rate metrics from predicted counts.
+- Keep neutral output schema unchanged.
+- Use leakage-safe shifted rolling features for snapshot construction.
+- Keep pybaseball priors optional with cache-first/offline fallbacks.

--- a/docs/plans/implemented/fantasy-rankings/phase-1.5-mlb-projection-quality-hardening-plan.md
+++ b/docs/plans/implemented/fantasy-rankings/phase-1.5-mlb-projection-quality-hardening-plan.md
@@ -1,6 +1,6 @@
 # Phase 1.5 Plan: MLB Batter Projection Quality Hardening (Feature Engineering + Walk-Forward Fit/Backtest)
 
-Status: Planned
+Status: Implemented
 
 ## Summary
 Phase 1 shipped a schema-valid MLB projection adapter. Phase 1.5 will harden projection quality before ranking/export phases by adding leakage-safe batter feature engineering, multi-season walk-forward training/backtesting, and pybaseball seasonal priors (Statcast-first policy).
@@ -188,7 +188,7 @@ Primary acceptance objective is out-of-sample MAE improvement.
 4. `README.md` (new offline dataset/backtest commands).
 5. `docs/plans/planned/fantasy-rankings/cross-sport-fantasy-rankings-architecture-roadmap.md` (add Phase 1.5 status line).
 6. Add plan doc:
-- `docs/plans/planned/fantasy-rankings/phase-1.5-mlb-projection-quality-hardening-plan.md`
+- `docs/plans/implemented/fantasy-rankings/phase-1.5-mlb-projection-quality-hardening-plan.md`
 
 ## Assumptions and Defaults
 1. Default anchor frequency is weekly.

--- a/docs/plans/implemented/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-findings.md
+++ b/docs/plans/implemented/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-findings.md
@@ -1,0 +1,175 @@
+# Phase 1.5a Hit-Rate Upstream Hardening Findings (Pre-Fix)
+
+Status: Archived (Historical Pre-Fix Findings)
+
+Date: 2026-02-14
+
+## Summary
+This document records post-implementation findings before code fixes. It captures:
+- Confirmed defects discovered in review.
+- Current modeling and testing signals from scoped E2E comparisons.
+- Known risks and acceptance gates to satisfy after remediation.
+
+This file is intentionally retained in `implemented/` as a historical checkpoint.
+It should not be treated as the latest post-fix acceptance record.
+
+## Scope and Dataset Context
+- Evaluation fold used in this report: 2025 season (train through 2024).
+- Scoped datasets used for fast iteration:
+  - `/tmp/batter_games_2021_2025_top100.parquet`
+  - `/tmp/batter_games_2021_2025_top300.parquet`
+- Comparator baseline: `main` branch run in worktree `/tmp/sportsbalf-main` using
+  the same harness and datasets.
+
+## Confirmed Defects
+### P1: Anchor-day games dropped from snapshot labels
+- Severity: P1
+- File: `src/fantasy/adapters/mlb/datasets.py`
+- Behavior:
+  - History uses `< anchor_date`.
+  - Future label uses `> anchor_date`.
+  - Games on `anchor_date` are excluded from both sides.
+- Impact:
+  - Systematic undercount in `target_rest_of_season_*`.
+  - Strongest risk when anchors are daily.
+  - Biases count labels downward for model training.
+
+### P2: Hard-hit fallback signal dropped in non-Statcast path
+- Severity: P2
+- File: `src/fantasy/adapters/mlb/datasets.py`
+- Behavior:
+  - `hard_hit_events` is created earlier in fallback logic.
+  - Later conversion guard checks for missing column, which is then never true.
+  - `hard_hit_rate -> hard_hit_events` conversion is skipped when only rate exists.
+- Impact:
+  - Hard-hit feature signal can be silently zeroed.
+  - Reduces feature quality for hit-rate-related modeling.
+
+## Modeling Results (Current vs Baseline)
+### Top100 (2025 fold)
+- Current:
+  - `hit_rate_mae`: `0.02284852370839386`
+  - `hits_mae`: `38.47352982441854`
+  - `plate_appearances_mae`: `146.80186464977405`
+  - `hit_rate_coverage`: `1.0`
+  - `hit_rate_extreme_fraction`: `0.0`
+  - `hit_rate_invalid_predictions`: `0`
+- Baseline (`main`):
+  - `hit_rate_mae`: `19.698855647059194`
+  - `hits_mae`: `63.18713769805639`
+  - `plate_appearances_mae`: `164.25817549661855`
+  - `hit_rate_coverage`: `0.35789473684210527`
+  - `hit_rate_extreme_fraction`: `1.0`
+  - `hit_rate_invalid_predictions`: `95`
+
+### Top300 (2025 fold)
+- Current:
+  - `hit_rate_mae`: `0.027228268086485822`
+  - `hits_mae`: `38.66469938832016`
+  - `plate_appearances_mae`: `159.37667710829683`
+  - `hit_rate_coverage`: `1.0`
+  - `hit_rate_extreme_fraction`: `0.0`
+  - `hit_rate_invalid_predictions`: `0`
+- Baseline (`main`):
+  - `hit_rate_mae`: `15.28944604101476`
+  - `hits_mae`: `53.40722639558069`
+  - `plate_appearances_mae`: `170.92260533186723`
+  - `hit_rate_coverage`: `0.4859437751004016`
+  - `hit_rate_extreme_fraction`: `1.0`
+  - `hit_rate_invalid_predictions`: `249`
+
+## Red Flags and Risk Assessment
+- Positive:
+  - Invalid prediction counts dropped to zero in scoped runs.
+  - Extreme-rate prediction fraction dropped to zero in scoped runs.
+  - Count and rate MAE improved materially versus baseline in scoped runs.
+- Open red flag:
+  - Coverage is `1.0` in current scoped runs, above target acceptance band
+    (`0.70` to `0.90`), indicating intervals are likely too wide.
+- Open risk:
+  - Defects P1/P2 can materially distort labels/features. Current gains are not
+    considered decision-final until fixes and re-evaluation.
+
+## Model-Family Sweep Findings (Current Branch)
+Runs executed on 2025 fold for fast comparison:
+- `poisson`
+- `elastic_net`
+- `hist_gradient_boosting`
+- `xgboost` (top100 only; top300 run was compute-heavy in interactive window)
+
+Observed pattern:
+- `elastic_net`, `hist_gradient_boosting`, and `xgboost` improved count MAEs
+  over `poisson` on top100.
+- `hist_gradient_boosting` and `elastic_net` improved count MAEs over `poisson`
+  on top300.
+- All tested models retained:
+  - `hit_rate_invalid_predictions = 0`
+  - `hit_rate_extreme_fraction = 0`
+  - `hit_rate_coverage = 1.0` (still over-wide).
+
+## Testing Methodology
+- Harness script: `/tmp/run_phase15a_e2e_eval.py`
+- Compared outputs:
+  - current branch (`feat/phase1-5-mlb-projection-quality-hardening`)
+  - baseline `main` in worktree (`/tmp/sportsbalf-main`)
+- Metrics captured:
+  - `hit_rate_mae`
+  - `hits_mae`
+  - `plate_appearances_mae`
+  - `hit_rate_coverage`
+  - `hit_rate_extreme_fraction`
+  - `hit_rate_invalid_predictions`
+- Additional artifacts:
+  - fold metric tables
+  - red-flag summary tables
+  - worst-error lists
+
+## Repro Commands
+Run scoped E2E for one dataset on the current branch checkout:
+
+```bash
+cd /Users/jbrys/sportsbalf
+PYTHONPATH=. ./.venv/bin/python /tmp/run_phase15a_e2e_eval.py \
+  --dataset /tmp/batter_games_2021_2025_top100.parquet \
+  --output-dir /tmp/e2e_phase15a_current_top100 \
+  --model-name poisson \
+  --season-min 2025 \
+  --season-max 2025
+```
+
+Run the baseline from the `main` worktree:
+
+```bash
+cd /tmp/sportsbalf-main
+PYTHONPATH=. /Users/jbrys/sportsbalf/.venv/bin/python /tmp/run_phase15a_e2e_eval.py \
+  --dataset /tmp/batter_games_2021_2025_top100.parquet \
+  --output-dir /tmp/e2e_phase15a_main_top100 \
+  --model-name poisson \
+  --season-min 2025 \
+  --season-max 2025
+```
+
+## Artifact Paths
+- Current scoped outputs:
+  - `/tmp/e2e_phase15a_current_top100`
+  - `/tmp/e2e_phase15a_current_top300`
+- Baseline scoped outputs:
+  - `/tmp/e2e_phase15a_main_top100`
+  - `/tmp/e2e_phase15a_main_top300`
+- Sweep outputs:
+  - `/tmp/e2e_phase15a_sweep_results.json`
+  - `/tmp/e2e_phase15a_current_top100_xgboost`
+
+## Pre-Fix Acceptance Criteria for Next Iteration
+After fixing P1/P2, rerun scoped evaluations and require:
+- `hit_rate`, `hits`, and `plate_appearances` MAE remain better than baseline.
+- `hit_rate_invalid_predictions = 0`.
+- `hit_rate_extreme_fraction` stays near zero.
+- Coverage calibrated into target band `0.70` to `0.90` for scoped folds.
+
+Then run wider/full-population evaluation before final sign-off.
+
+## Follow-up Plan
+The next planned iteration for improving hit-rate-family point accuracy and
+uncertainty calibration is documented in:
+- `docs/plans/planned/fantasy-rankings/phase-1.5b-hit-rate-accuracy-calibration-plan.md`

--- a/docs/plans/implemented/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-plan.md
+++ b/docs/plans/implemented/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-plan.md
@@ -1,6 +1,6 @@
 # Phase 1.5a Plan: Fix `hit_rate` by hardening upstream `hits` + `plate_appearances` first
 
-Status: Planned
+Status: Implemented
 
 ## Summary
 We will address the worst metric (`hit_rate`) by improving its upstream count predictions (`hits`, `plate_appearances`) end-to-end, then re-derive `hit_rate` from those improved counts.
@@ -170,3 +170,18 @@ For `hits` and `plate_appearances`, train on:
 - Baseline comparator for acceptance remains the current Phase 1.5 adapter e2e run artifacts.
 - Regular-season-only filtering is default and required for this metric pass.
 - Weekly anchors remain default for stability/performance balance.
+
+## Post-Implementation Findings (Pre-Fix)
+Date: 2026-02-14
+
+Implementation is complete, but two post-implementation defects were identified and
+must be fixed before final acceptance:
+- Anchor-day labeling bug in snapshot target construction (`src/fantasy/adapters/mlb/datasets.py`).
+- Hard-hit fallback conversion bug when only `hard_hit_rate` is available (`src/fantasy/adapters/mlb/datasets.py`).
+
+Detailed issue log, modeling results, and testing notes are documented in:
+- `docs/plans/implemented/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-findings.md`
+
+## Follow-up Plan
+Next iteration planning for accuracy and interval calibration is tracked in:
+- `docs/plans/planned/fantasy-rankings/phase-1.5b-hit-rate-accuracy-calibration-plan.md`

--- a/docs/plans/planned/fantasy-rankings/cross-sport-fantasy-rankings-architecture-roadmap.md
+++ b/docs/plans/planned/fantasy-rankings/cross-sport-fantasy-rankings-architecture-roadmap.md
@@ -11,7 +11,9 @@ Implementation remains phased and small-scope, with explicit extensibility gates
    - `docs/plans/implemented/fantasy-rankings/phase-0-unified-projection-core-plan.md`
 2. Phase 1 is implemented and tracked at:
    - `docs/plans/implemented/fantasy-rankings/phase-1-mlb-projection-adapter-plan.md`
-3. Remaining phases (2-5) are still planned.
+3. Phase 1.5 is implemented and tracked at:
+   - `docs/plans/implemented/fantasy-rankings/phase-1.5-mlb-projection-quality-hardening-plan.md`
+4. Remaining phases (2-5) are still planned.
 
 ## Locked Architecture Principles (Non-Negotiable)
 1. Core is sport-agnostic.

--- a/docs/plans/planned/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-plan.md
+++ b/docs/plans/planned/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-plan.md
@@ -1,0 +1,172 @@
+# Phase 1.5a Plan: Fix `hit_rate` by hardening upstream `hits` + `plate_appearances` first
+
+Status: Planned
+
+## Summary
+We will address the worst metric (`hit_rate`) by improving its upstream count predictions (`hits`, `plate_appearances`) end-to-end, then re-derive `hit_rate` from those improved counts.
+This plan focuses on two fundamentals:
+
+1. Data cleaning correctness (regular-season-only canonical batter-game truth, robust snapshot labels).
+2. Feature engineering quality (playing-time and contact-quality features that stabilize count forecasts).
+
+Key observed problems from current full-data e2e:
+- `hit_rate` is worst (`+218.6%` MAE vs baseline).
+- Extreme predictions (e.g., rate near `0.8`) indicate unstable upstream counts.
+- Count/rate outputs still produce invalid negatives in many rows.
+- Sparse-player filtering alone does not fix the MAE regression materially.
+
+User-selected strategy: upstream counts first.
+
+## Scope
+### In scope
+- Rebuild the `hits` and `plate_appearances` season-horizon modeling path on snapshot/rest-of-season labels.
+- Clean and harden batter-game inputs used for those two targets.
+- Derive `hit_rate` only from improved `hits` + `plate_appearances`.
+- Add walk-forward evaluation and red-flag diagnostics specific to this metric family.
+
+### Out of scope (this pass)
+- Other metrics (`walk_rate`, `slugging_proxy`, etc.) except incidental compatibility.
+- Full multi-metric feature overhaul.
+- Provider/export logic changes.
+
+## Design (decision complete)
+
+### 1) Canonical cleaned batter-game dataset for this pass
+Create a cleaned training view for `hits`/`PA` with explicit rules:
+- Source: `statcast_raw_2021..2025.parquet`.
+- Keep only `game_type == "R"` (regular season).
+- Plate appearance terminal row selection:
+  - Keep `events` not null and not `"none"/"nan"`.
+  - Sort by `pitch_number`.
+  - Deduplicate on `["game_pk", "batter", "game_date", "at_bat_number"]` (explicit batter key).
+- Aggregate to batter-game (`["batter","game_date","game_pk"]` first, then daily rollup as needed).
+- Enforce nonnegative integer-ish domains:
+  - `plate_appearances >= 0`, `hits >= 0`, `hits <= plate_appearances`.
+- Add cleaning audit columns in intermediate tables (not required in final adapter output):
+  - `is_regular_season`, `pa_terminal_dedup_applied`, `qa_invalid_row_flag`.
+
+### 2) Snapshot labeling strategy (replace per-game scaled season projection for these targets)
+For `hits` and `plate_appearances`, train on:
+- Entity: `(player_id, season, anchor_date)` weekly anchors.
+- Features: all prior-to-anchor only.
+- Labels:
+  - `target_rest_of_season_hits`
+  - `target_rest_of_season_plate_appearances`
+- Inference semantics:
+  - Predict remaining-season counts.
+  - Final season forecast for each count = `season_to_date + predicted_remaining` (in-season anchors).
+  - Preseason: remaining-only.
+
+### 3) Feature engineering (metric-focused)
+#### `plate_appearances` model features
+- Existing leakage-safe rolling features (7/14/30) for:
+  - `PA`, `games_played`, `PA/game`, `days_since_last_game`.
+- Add exposure/stability features:
+  - `team_games_seen_last_30` (from available game rows),
+  - `player_game_share_last_30`,
+  - `recent_consecutive_games_played`.
+- Add split usage:
+  - rolling `pa_vs_lhp_share`, `pa_vs_rhp_share`.
+
+#### `hits` model features
+- Include all PA-model features plus contact/performance:
+  - rolling `hits`, `hit_rate`, `hard_hit_rate`, `total_bases`, `slugging_proxy`.
+- Add empirical-Bayes smoothed hit-rate priors:
+  - `smoothed_hit_rate_rolling_30`,
+  - `smoothed_hit_rate_season_to_date`,
+  - league prior fallback.
+- Keep features strictly pre-anchor and numeric-safe.
+
+### 4) Modeling approach
+- PA model: direct regression on remaining PA counts.
+- Hits model: direct regression on remaining hits counts, with predicted remaining PA as a feature during inference.
+- Candidate models: `poisson`, `elastic_net`, `hist_gradient_boosting`, `xgboost`.
+- Selection: walk-forward MAE on target metric, RMSE tie-break.
+- Prediction constraints:
+  - `pred_remaining_pa = max(pred, 0)`
+  - `pred_remaining_hits = max(pred, 0)`
+  - `pred_remaining_hits <= pred_remaining_pa` (consistency constraint).
+- Derive `hit_rate` from constrained totals:
+  - `hit_rate = total_hits / total_pa` when `total_pa > 0`, else `0`.
+
+### 5) Uncertainty
+- Build OOS residual banks from walk-forward for both count models.
+- Bucket residuals by `season_to_date_pa` buckets.
+- For `hit_rate` intervals:
+  - Monte Carlo sample count residuals jointly (independent first pass, optional correlation in next pass),
+  - enforce count constraints per draw,
+  - transform draws to rate quantiles (`p10/p50/p90`) and stddev.
+- Ensure non-degenerate but bounded output:
+  - `0 <= p10 <= p50 <= p90 <= 1`.
+
+## Public API / interface changes
+1. `src/fantasy/adapters/mlb/projection_adapter.py`
+- Internal API addition (non-breaking public entrypoint):
+  - dedicated snapshot-based path for `hits` and `plate_appearances`.
+- Keep `project(config)` signature unchanged.
+
+2. Config additions under `adapters.mlb_projection_phase15` (non-breaking):
+- `data_cleaning.regular_season_only: bool` (default `true`)
+- `data_cleaning.require_batter_pa_dedup: bool` (default `true`)
+- `modeling.count_nonnegative_constraints: bool` (default `true`)
+- `modeling.hits_leq_pa_constraint: bool` (default `true`)
+- `modeling.hit_rate_derivation_source: "counts_only"` (default)
+- `evaluation.primary_metric_focus: "hit_rate"`
+
+3. New/updated artifacts:
+- walk-forward diagnostics CSV with per-fold red-flag columns.
+- no changes to neutral projection output schema.
+
+## Implementation steps
+1. Add cleaned batter-game builder for `hits`/`PA` training view.
+2. Extend snapshot builder to produce explicit labels/features for these two targets.
+3. Implement metric-specific feature sets for PA and hits models.
+4. Replace current per-game-scaled season path for these two metrics with snapshot models.
+5. Add count consistency constraints before deriving `hit_rate`.
+6. Update uncertainty path to sample from count residual banks and transform to rate intervals.
+7. Add e2e walk-forward evaluation runner for this metric family.
+8. Wire diagnostics/red-flag report generation.
+9. Update docs/config schema for new knobs and semantics.
+
+## Tests and scenarios
+### Unit tests
+- Cleaning:
+  - regular-season filter applied when `game_type` present.
+  - dedup keys produce one terminal row per batter PA.
+  - invalid rows (`hits > PA`, negative values) are corrected/flagged.
+- Snapshot leakage:
+  - no post-anchor rows used in features.
+- Constraint correctness:
+  - `pred_hits >= 0`, `pred_pa >= 0`, `pred_hits <= pred_pa`.
+  - derived `hit_rate` always in `[0,1]`.
+
+### Integration tests
+- Adapter outputs unchanged schema and deterministic ordering.
+- `source_model_version` reflects selected/fallback model correctly.
+- Uncertainty monotonicity and bounded rate intervals.
+
+### E2E acceptance (full dataset)
+- Walk-forward on folds: train<=N-1, test=N for 2022..2025.
+- Pass criteria:
+  - `hit_rate` MAE improves by at least 20% vs current Phase 1.5 adapter baseline run.
+  - `hits` and `PA` each improve MAE by at least 10% vs current run.
+  - `hit_rate` fold rows with `|bias| > 0.03` are reduced by at least 50%.
+  - `p10-p90` coverage for `hit_rate` in `[0.70, 0.90]` for each fold.
+  - Zero invalid projections:
+    - no negative means for `hits`/`PA`,
+    - no `hit_rate` outside `[0,1]`.
+
+## Red-flag dashboard (must be emitted each run)
+- Worst 20 entities by absolute `hit_rate` error.
+- Fraction of predictions at extreme rates (`>0.45`, `<0.10`) with actual comparison.
+- Fold-level:
+  - MAE delta vs baseline,
+  - bias,
+  - coverage,
+  - invalid prediction counts.
+
+## Assumptions and defaults
+- `hit_rate` remains a derived metric, not directly predicted in this pass.
+- Baseline comparator for acceptance remains the current Phase 1.5 adapter e2e run artifacts.
+- Regular-season-only filtering is default and required for this metric pass.
+- Weekly anchors remain default for stability/performance balance.

--- a/docs/plans/planned/fantasy-rankings/phase-1.5b-hit-rate-accuracy-calibration-plan.md
+++ b/docs/plans/planned/fantasy-rankings/phase-1.5b-hit-rate-accuracy-calibration-plan.md
@@ -1,0 +1,167 @@
+# Phase 1.5b Plan: Hit-Rate Family Accuracy and Calibration Hardening
+
+Status: In Progress
+
+Date: 2026-02-14
+
+## Summary
+This plan targets the next accuracy iteration for the Phase 1.5 hit-rate family:
+`hit_rate`, `hits`, and `plate_appearances`.
+
+Phase 1.5a established major point-accuracy gains and fixed critical upstream
+defects (P1/P2). The primary remaining quality gap from findings is interval
+calibration: `hit_rate_coverage` was over-wide in scoped runs. Phase 1.5b keeps
+the same output contract while improving model selection rigor and uncertainty
+calibration quality.
+
+## Goals
+- Improve point-forecast robustness for `hits` and `plate_appearances`.
+- Improve derived `hit_rate` accuracy through stronger count model selection.
+- Calibrate `hit_rate` uncertainty intervals into target coverage band.
+- Preserve no-invalid-prediction guarantees and stable interfaces.
+
+## Scope
+### In scope
+- MLB Phase 1.5 adapter path for:
+  - `hit_rate`
+  - `hits`
+  - `plate_appearances`
+- Walk-forward model-family selection and diagnostics.
+- Hit-rate uncertainty calibration from count residual simulation.
+- Additional deterministic acceptance gates and reporting.
+
+### Out of scope
+- Other Phase 1.5 stats (`walk_rate`, `slugging_proxy`, etc.).
+- Provider/export schema changes.
+- Breaking API changes.
+
+## Baseline and Problem Statement
+- Baseline context is documented in:
+  - `docs/plans/implemented/fantasy-rankings/phase-1.5a-hit-rate-upstream-hardening-findings.md`
+- Findings show:
+  - Material point-accuracy improvement vs `main`.
+  - Invalid predictions and extreme-rate issues resolved in scoped runs.
+  - Remaining red flag: `hit_rate_coverage = 1.0` in scoped runs (target
+    acceptance band: `0.70` to `0.90`).
+
+## Design (Decision Complete)
+
+### 1) Post-fix baseline freeze
+- Capture post-P1/P2 reference artifacts for:
+  - Scoped 2025 fold (top100, top300).
+  - Full walk-forward folds (2022..2025).
+- Treat these artifacts as the comparator for Phase 1.5b acceptance.
+
+### 2) Count model selection hardening
+- Candidate families remain:
+  - `poisson`
+  - `elastic_net`
+  - `hist_gradient_boosting`
+  - `xgboost`
+- Selection policy:
+  - Primary metric: fold MAE on target count.
+  - Tie-break 1: RMSE.
+  - Tie-break 2: absolute bias.
+- Add anti-churn threshold:
+  - Promote non-default winner only when MAE delta exceeds a configurable
+    minimum improvement threshold.
+
+### 3) Feature-group ablation gate
+- Evaluate incremental effect of feature groups on out-of-fold performance:
+  - playing-time/exposure features
+  - contact-quality features
+  - smoothed priors
+- Keep groups only when they improve MAE or reduce bias without destabilizing
+  inference behavior.
+
+### 4) Hit-rate uncertainty calibration
+- Keep count-derived Monte Carlo interval generation.
+- Introduce deterministic residual scaling controls:
+  - global residual scale multiplier
+  - optional bucket-specific multipliers by `season_to_date_pa` buckets
+- Calibrate multipliers using walk-forward objective:
+  - minimize coverage error toward target center (`0.80`)
+  - penalize unnecessarily wide intervals (`p90 - p10`)
+- Keep hard bounds and monotonic quantiles:
+  - `0 <= p10 <= p50 <= p90 <= 1`
+
+### 5) Residual-bank quality controls
+- Require minimum residual count per bucket before bucket-specific use.
+- Fall back to default/global residual bank for sparse buckets.
+- Emit residual-support diagnostics by fold and bucket.
+
+### 6) Red-flag dashboard expansion
+- Retain existing key metrics and add:
+  - median interval width (`p90 - p10`)
+  - p95 interval width
+  - coverage error vs target center (`0.80`)
+  - selected model family per target/fold
+  - active uncertainty scale metadata
+
+## Public API / Interface Changes
+- No external output schema changes.
+- No `project(config)` signature changes.
+
+### Non-breaking config additions (under `adapters.mlb_projection_phase15`)
+- `modeling.selection_min_delta_mae: float` (default `0.0`)
+- `uncertainty.hit_rate_residual_scale_global: float` (default `1.0`)
+- `uncertainty.hit_rate_residual_scale_by_bucket: dict[str, float]` (default `{}`)
+- `uncertainty.coverage_target: float` (default `0.80`)
+- `uncertainty.calibration_objective: str` (default `"coverage_width_tradeoff"`)
+- `uncertainty.min_bucket_residual_count: int` (default `100`)
+
+## Acceptance Criteria
+Run walk-forward folds 2022..2025 and require all:
+- `hit_rate_mae` improved by >= 20% vs comparator baseline.
+- `hits_mae` improved by >= 10% vs comparator baseline.
+- `plate_appearances_mae` improved by >= 10% vs comparator baseline.
+- `hit_rate_invalid_predictions = 0`.
+- `hit_rate_extreme_fraction` remains near zero with no regression.
+- `hit_rate` coverage in `[0.70, 0.90]` per fold.
+- No catastrophic fold regression (>10% MAE degradation) vs post-fix reference.
+
+## Test Plan
+### Unit tests
+- Uncertainty calibration preserves bounds and quantile monotonicity.
+- Bucket fallback triggers when residual support is below threshold.
+- Calibration objective ranking is deterministic with fixed seed.
+
+### Integration tests
+- Adapter output schema and ordering unchanged.
+- Source model provenance fields remain populated and deterministic.
+- Red-flag dashboard emits new calibration/width metadata columns.
+
+### E2E tests
+- Scoped top100/top300 2025 fold checks.
+- Full walk-forward folds 2022..2025 with gate evaluation table.
+
+## Implementation Steps
+1. Freeze and persist post-fix comparator artifacts.
+2. Add config keys and defaults for selection/calibration controls.
+3. Implement model-selection threshold logic.
+4. Add feature-group ablation runner and summary artifact.
+5. Implement uncertainty scaling and calibration objective scoring.
+6. Add residual support thresholds and fallback behavior.
+7. Expand red-flag dashboard outputs.
+8. Execute scoped + walk-forward evaluation and apply gates.
+9. Update docs (`README.md`, `docs/config-schema.md`, `docs/contracts.md`,
+   `docs/architecture.md`) for any new keys/diagnostics.
+
+## Implementation Progress (2026-02-14)
+- Completed:
+  - Step 2: config keys/defaults wired in adapter config parsing.
+  - Step 3: model selection anti-churn threshold logic implemented.
+  - Step 5: hit-rate uncertainty residual scaling controls implemented.
+  - Step 6: bucket residual minimum-support fallback implemented.
+  - Step 7: red-flag dashboard now emits interval-width and coverage-target diagnostics.
+  - Step 9: docs/config updates landed for new controls.
+- Remaining:
+  - Step 1: persist post-fix comparator artifacts for acceptance baseline.
+  - Step 4: add feature-group ablation runner/artifact.
+  - Step 8: run scoped + full walk-forward gate evaluation against comparator.
+
+## Assumptions and Defaults
+- Scope is limited to hit-rate family metrics only.
+- Phase 1.5a P1/P2 bug fixes are present before this plan starts.
+- Coverage target center is `0.80` with acceptable band `[0.70, 0.90]`.
+- Offline deterministic backtests remain the acceptance source of truth.

--- a/scripts/backtest_mlb_fantasy_projections.py
+++ b/scripts/backtest_mlb_fantasy_projections.py
@@ -1,0 +1,37 @@
+"""Run a lightweight walk-forward summary for MLB fantasy projection metrics."""
+
+from __future__ import annotations
+
+import argparse
+
+import pandas as pd
+from src.fantasy.adapters.mlb.backtest import (
+    aggregate_metric_scores,
+    generate_walk_forward_folds,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--predictions",
+        required=True,
+        help="CSV path with metric_id,prediction,actual,season.",
+    )
+    parser.add_argument(
+        "--output", required=True, help="Output CSV path for aggregated scores."
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    frame = pd.read_csv(args.predictions)
+    seasons = tuple(int(value) for value in sorted(frame["season"].dropna().unique()))
+    _folds = generate_walk_forward_folds(seasons)
+    scores = aggregate_metric_scores(frame)
+    scores.to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_mlb_batter_projection_dataset.py
+++ b/scripts/build_mlb_batter_projection_dataset.py
@@ -1,0 +1,48 @@
+"""Build Phase 1.5 MLB batter snapshot dataset for projection modeling."""
+
+from __future__ import annotations
+
+import argparse
+
+from src.fantasy.adapters.mlb.datasets import build_player_season_snapshots
+from src.fantasy.adapters.mlb.features import prepare_mlb_projection_frame
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input", required=True, help="Input batter-game CSV/Parquet path."
+    )
+    parser.add_argument("--output", required=True, help="Output snapshot CSV path.")
+    parser.add_argument("--metric", default="hits", help="Count metric label target.")
+    parser.add_argument(
+        "--snapshot-anchor-frequency",
+        default="weekly",
+        choices=("weekly", "daily"),
+    )
+    parser.add_argument("--snapshot-min-games", type=int, default=5)
+    parser.add_argument("--entity-id-col", default="batter")
+    parser.add_argument("--date-col", default="game_date")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    frame = prepare_mlb_projection_frame(
+        args.input,
+        entity_id_col=args.entity_id_col,
+        date_col=args.date_col,
+    )
+    snapshot = build_player_season_snapshots(
+        frame,
+        entity_id_col=args.entity_id_col,
+        date_col=args.date_col,
+        target_col=args.metric,
+        snapshot_min_games=args.snapshot_min_games,
+        snapshot_anchor_frequency=args.snapshot_anchor_frequency,
+    )
+    snapshot.to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fantasy/adapters/mlb/__init__.py
+++ b/src/fantasy/adapters/mlb/__init__.py
@@ -1,5 +1,16 @@
 """MLB fantasy projection adapters."""
 
+from src.fantasy.adapters.mlb.backtest import (
+    WalkForwardFold,
+    aggregate_metric_scores,
+    generate_walk_forward_folds,
+)
+from src.fantasy.adapters.mlb.datasets import build_player_season_snapshots
+from src.fantasy.adapters.mlb.feature_engineering import add_phase15_rolling_features
+from src.fantasy.adapters.mlb.priors import (
+    attach_priors_to_snapshots,
+    load_cached_priors,
+)
 from src.fantasy.adapters.mlb.projection_adapter import (
     MlbProjectionAdapterConfig,
     MlbSeasonProjectionAdapter,
@@ -13,5 +24,12 @@ __all__ = [
     "MlbProjectionAdapterConfig",
     "MlbSeasonProjectionAdapter",
     "PHASE1_MLB_METRICS",
+    "WalkForwardFold",
+    "add_phase15_rolling_features",
+    "aggregate_metric_scores",
+    "attach_priors_to_snapshots",
+    "build_player_season_snapshots",
+    "generate_walk_forward_folds",
+    "load_cached_priors",
     "register_mlb_projection_adapters",
 ]

--- a/src/fantasy/adapters/mlb/__init__.py
+++ b/src/fantasy/adapters/mlb/__init__.py
@@ -3,9 +3,13 @@
 from src.fantasy.adapters.mlb.backtest import (
     WalkForwardFold,
     aggregate_metric_scores,
+    build_hit_rate_red_flag_dashboard,
     generate_walk_forward_folds,
 )
-from src.fantasy.adapters.mlb.datasets import build_player_season_snapshots
+from src.fantasy.adapters.mlb.datasets import (
+    build_hits_pa_training_view,
+    build_player_season_snapshots,
+)
 from src.fantasy.adapters.mlb.feature_engineering import add_phase15_rolling_features
 from src.fantasy.adapters.mlb.priors import (
     attach_priors_to_snapshots,
@@ -27,7 +31,9 @@ __all__ = [
     "WalkForwardFold",
     "add_phase15_rolling_features",
     "aggregate_metric_scores",
+    "build_hit_rate_red_flag_dashboard",
     "attach_priors_to_snapshots",
+    "build_hits_pa_training_view",
     "build_player_season_snapshots",
     "generate_walk_forward_folds",
     "load_cached_priors",

--- a/src/fantasy/adapters/mlb/backtest.py
+++ b/src/fantasy/adapters/mlb/backtest.py
@@ -1,0 +1,64 @@
+"""Walk-forward backtest helpers for Phase 1.5 MLB fantasy projections."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardFold:
+    """Single walk-forward fold definition."""
+
+    train_seasons: tuple[int, ...]
+    test_season: int
+
+
+def generate_walk_forward_folds(
+    seasons: tuple[int, ...]
+) -> tuple[WalkForwardFold, ...]:
+    """Generate `(train through N-1, test on N)` folds."""
+
+    ordered = tuple(sorted({int(season) for season in seasons}))
+    if len(ordered) < 2:
+        return ()
+
+    folds: list[WalkForwardFold] = []
+    for index in range(1, len(ordered)):
+        train = ordered[:index]
+        test = ordered[index]
+        folds.append(WalkForwardFold(train_seasons=train, test_season=test))
+    return tuple(folds)
+
+
+def aggregate_metric_scores(predictions: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate MAE/RMSE/bias by metric id from row-level predictions."""
+
+    required = {"metric_id", "prediction", "actual"}
+    if not required.issubset(predictions.columns):
+        return pd.DataFrame(columns=["metric_id", "mae", "rmse", "bias", "n"])
+    if predictions.empty:
+        return pd.DataFrame(columns=["metric_id", "mae", "rmse", "bias", "n"])
+
+    frame = predictions.copy()
+    frame["prediction"] = pd.to_numeric(frame["prediction"], errors="coerce")
+    frame["actual"] = pd.to_numeric(frame["actual"], errors="coerce")
+    frame = frame.dropna(subset=["prediction", "actual"]).copy()
+    if frame.empty:
+        return pd.DataFrame(columns=["metric_id", "mae", "rmse", "bias", "n"])
+
+    frame["error"] = frame["prediction"] - frame["actual"]
+    frame["abs_error"] = frame["error"].abs()
+    frame["sq_error"] = frame["error"] ** 2
+
+    grouped = frame.groupby("metric_id", dropna=False)
+    summary = grouped.agg(
+        mae=("abs_error", "mean"),
+        mse=("sq_error", "mean"),
+        bias=("error", "mean"),
+        n=("error", "size"),
+    ).reset_index()
+    summary["rmse"] = summary["mse"].map(lambda value: math.sqrt(float(value)))
+    return summary[["metric_id", "mae", "rmse", "bias", "n"]]

--- a/src/fantasy/adapters/mlb/backtest.py
+++ b/src/fantasy/adapters/mlb/backtest.py
@@ -62,3 +62,112 @@ def aggregate_metric_scores(predictions: pd.DataFrame) -> pd.DataFrame:
     ).reset_index()
     summary["rmse"] = summary["mse"].map(lambda value: math.sqrt(float(value)))
     return summary[["metric_id", "mae", "rmse", "bias", "n"]]
+
+
+def build_hit_rate_red_flag_dashboard(
+    predictions: pd.DataFrame,
+    *,
+    baseline_scores: pd.DataFrame | None = None,
+    coverage_target: float = 0.80,
+) -> pd.DataFrame:
+    """Build per-fold hit-rate red-flag diagnostics from walk-forward rows."""
+
+    required = {
+        "entity_id",
+        "fold",
+        "metric_id",
+        "prediction",
+        "actual",
+        "p10",
+        "p90",
+    }
+    if not required.issubset(predictions.columns):
+        return pd.DataFrame()
+    frame = predictions.copy()
+    frame["metric_id"] = frame["metric_id"].astype(str).str.strip().str.lower()
+    frame = frame[frame["metric_id"].isin({"hit_rate", "hits", "plate_appearances"})]
+    if frame.empty:
+        return pd.DataFrame()
+
+    frame["prediction"] = pd.to_numeric(frame["prediction"], errors="coerce")
+    frame["actual"] = pd.to_numeric(frame["actual"], errors="coerce")
+    frame["p10"] = pd.to_numeric(frame["p10"], errors="coerce")
+    frame["p90"] = pd.to_numeric(frame["p90"], errors="coerce")
+    frame = frame.dropna(subset=["prediction", "actual"]).copy()
+    if frame.empty:
+        return pd.DataFrame()
+
+    frame["abs_error"] = (frame["prediction"] - frame["actual"]).abs()
+    frame["error"] = frame["prediction"] - frame["actual"]
+    frame["covered"] = (frame["actual"] >= frame["p10"]) & (
+        frame["actual"] <= frame["p90"]
+    )
+    frame["invalid_prediction"] = frame["prediction"].lt(0.0)
+    hit_rows = frame[frame["metric_id"] == "hit_rate"].copy()
+    if hit_rows.empty:
+        return pd.DataFrame()
+    hit_rows["invalid_prediction"] = hit_rows["invalid_prediction"] | hit_rows[
+        "prediction"
+    ].gt(1.0)
+    hit_rows["extreme_rate"] = hit_rows["prediction"].gt(0.45) | hit_rows[
+        "prediction"
+    ].lt(0.10)
+    hit_rows["interval_width"] = (hit_rows["p90"] - hit_rows["p10"]).clip(lower=0.0)
+
+    metadata_cols = {
+        "selected_model_family": "selected_model_family",
+        "active_uncertainty_scale": "active_uncertainty_scale",
+    }
+    available_metadata = {
+        source: target
+        for source, target in metadata_cols.items()
+        if source in hit_rows.columns
+    }
+
+    agg_spec: dict[str, tuple[str, str | object]] = {
+        "hit_rate_mae": ("abs_error", "mean"),
+        "hit_rate_bias": ("error", "mean"),
+        "hit_rate_coverage": ("covered", "mean"),
+        "hit_rate_invalid_predictions": ("invalid_prediction", "sum"),
+        "hit_rate_extreme_fraction": ("extreme_rate", "mean"),
+        "hit_rate_n": ("entity_id", "size"),
+        "hit_rate_bias_gt_0p03_fraction": (
+            "error",
+            lambda s: (s.abs() > 0.03).mean(),
+        ),
+        "hit_rate_interval_width_median": ("interval_width", "median"),
+        "hit_rate_interval_width_p95": (
+            "interval_width",
+            lambda s: s.quantile(0.95),
+        ),
+    }
+    for source_col, target_col in available_metadata.items():
+        agg_spec[target_col] = (
+            source_col,
+            lambda s: next((str(value) for value in s if pd.notna(value)), ""),
+        )
+
+    summary = (
+        hit_rows.groupby("fold", dropna=False)
+        .agg(**agg_spec)
+        .reset_index()
+    )
+    summary["hit_rate_coverage_error_vs_target"] = (
+        summary["hit_rate_coverage"] - float(coverage_target)
+    ).abs()
+    if baseline_scores is not None and not baseline_scores.empty:
+        baseline = baseline_scores.copy()
+        baseline["fold"] = baseline["fold"].astype(str)
+        baseline["baseline_hit_rate_mae"] = pd.to_numeric(
+            baseline.get("baseline_hit_rate_mae", float("nan")), errors="coerce"
+        )
+        summary["fold"] = summary["fold"].astype(str)
+        summary = summary.merge(
+            baseline.loc[:, ["fold", "baseline_hit_rate_mae"]],
+            on="fold",
+            how="left",
+        )
+        summary["mae_delta_vs_baseline"] = (
+            summary["hit_rate_mae"] - summary["baseline_hit_rate_mae"]
+        )
+    return summary.sort_values("fold", kind="stable").reset_index(drop=True)

--- a/src/fantasy/adapters/mlb/datasets.py
+++ b/src/fantasy/adapters/mlb/datasets.py
@@ -2,17 +2,38 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 
 import pandas as pd
 
 from src.fantasy.adapters.mlb.feature_engineering import add_phase15_rolling_features
 
+logger = logging.getLogger(__name__)
+
 SNAPSHOT_FEATURE_PREFIXES: tuple[str, ...] = (
     "roll_",
     "games_played_",
     "pa_per_game_",
 )
+SNAPSHOT_EXTRA_FEATURE_COLUMNS: tuple[str, ...] = (
+    "days_since_last_game",
+    "hard_hit_rate",
+    "team_games_seen_last_30",
+    "player_game_share_last_30",
+    "recent_consecutive_games_played",
+    "smoothed_hit_rate_rolling_30",
+    "smoothed_hit_rate_season_to_date",
+)
+_HIT_EVENTS: frozenset[str] = frozenset({"single", "double", "triple", "home_run"})
+_WALK_EVENTS: frozenset[str] = frozenset({"walk", "intent_walk"})
+_STRIKEOUT_EVENTS: frozenset[str] = frozenset({"strikeout", "strikeout_double_play"})
+_TOTAL_BASES_BY_EVENT: dict[str, int] = {
+    "single": 1,
+    "double": 2,
+    "triple": 3,
+    "home_run": 4,
+}
 
 
 def _normalize_anchor_frequency(value: str) -> str:
@@ -41,8 +62,246 @@ def _snapshot_feature_columns(frame: pd.DataFrame) -> list[str]:
         column
         for column in frame.columns
         if column.startswith(SNAPSHOT_FEATURE_PREFIXES)
-        or column in {"days_since_last_game", "hard_hit_rate"}
+        or column in SNAPSHOT_EXTRA_FEATURE_COLUMNS
     ]
+
+
+def _event_series(frame: pd.DataFrame) -> pd.Series:
+    return (
+        frame.get("events", pd.Series("", index=frame.index))
+        .astype(str)
+        .str.strip()
+        .str.lower()
+    )
+
+
+def _coerce_numeric(frame: pd.DataFrame, column: str) -> pd.Series:
+    return pd.to_numeric(frame.get(column, 0.0), errors="coerce").fillna(0.0)
+
+
+def build_hits_pa_training_view(
+    frame: pd.DataFrame,
+    *,
+    entity_id_col: str,
+    date_col: str,
+    regular_season_only: bool = True,
+    require_batter_pa_dedup: bool = True,
+) -> pd.DataFrame:
+    """Build cleaned batter-game rows for `hits` and `plate_appearances`.
+
+    Args:
+        frame: Raw/normalized MLB frame.
+        entity_id_col: Batter id column.
+        date_col: Game date column.
+        regular_season_only: Keep only `game_type == "R"` when available.
+        require_batter_pa_dedup: Deduplicate to PA terminal pitch rows when available.
+
+    Returns:
+        Cleaned daily batter rows with constraint-safe count columns and QA flags.
+    """
+
+    if frame.empty:
+        return pd.DataFrame()
+
+    working = frame.copy()
+    if entity_id_col not in working.columns:
+        working[entity_id_col] = ""
+    if date_col not in working.columns:
+        working[date_col] = pd.NaT
+    working[entity_id_col] = working[entity_id_col].astype(str).str.strip()
+    working[date_col] = pd.to_datetime(working[date_col], errors="coerce")
+    working = working.dropna(subset=[date_col]).copy()
+    working = working[working[entity_id_col].ne("")].copy()
+    if working.empty:
+        return pd.DataFrame()
+
+    working["is_regular_season"] = True
+    if "game_type" in working.columns:
+        working["is_regular_season"] = (
+            working["game_type"].astype(str).str.strip().str.upper().eq("R")
+        )
+    if regular_season_only:
+        working = working[working["is_regular_season"]].copy()
+    if working.empty:
+        return pd.DataFrame()
+
+    dedup_applied = False
+    dedup_keys = ["game_pk", entity_id_col, date_col, "at_bat_number"]
+    can_dedup = require_batter_pa_dedup and set(dedup_keys).issubset(working.columns)
+    if can_dedup:
+        events = _event_series(working)
+        valid_events = events.ne("") & ~events.isin({"none", "nan"})
+        working = working[valid_events].copy()
+        if not working.empty:
+            if "pitch_number" in working.columns:
+                working["pitch_number"] = pd.to_numeric(
+                    working["pitch_number"], errors="coerce"
+                ).fillna(0.0)
+                working = working.sort_values(
+                    dedup_keys + ["pitch_number"], kind="stable"
+                )
+            else:
+                working = working.sort_values(dedup_keys, kind="stable")
+            working = working.drop_duplicates(subset=dedup_keys, keep="last")
+            dedup_applied = True
+    working["pa_terminal_dedup_applied"] = bool(dedup_applied)
+
+    if working.empty:
+        return pd.DataFrame()
+
+    if "game_pk" in working.columns and "events" in working.columns:
+        events = _event_series(working)
+        hit_flag = events.isin(_HIT_EVENTS).astype("float64")
+        total_bases = events.map(_TOTAL_BASES_BY_EVENT).fillna(0).astype("float64")
+        walk_flag = events.isin(_WALK_EVENTS).astype("float64")
+        strikeout_flag = events.isin(_STRIKEOUT_EVENTS).astype("float64")
+
+        hard_hit_events = pd.Series(0.0, index=working.index, dtype="float64")
+        if "launch_speed" in working.columns:
+            launch_speed = pd.to_numeric(
+                working["launch_speed"], errors="coerce"
+            ).fillna(0.0)
+            hard_hit_events = launch_speed.ge(95.0).astype("float64")
+        elif "hard_hit_events" in working.columns:
+            hard_hit_events = _coerce_numeric(working, "hard_hit_events")
+        elif "hard_hit_rate" in working.columns:
+            hard_hit_events = _coerce_numeric(
+                working, "hard_hit_rate"
+            ) * _coerce_numeric(working, "plate_appearances").clip(lower=0.0)
+
+        pa_vs_lhp = pd.Series(0.0, index=working.index, dtype="float64")
+        pa_vs_rhp = pd.Series(0.0, index=working.index, dtype="float64")
+        if "pitcher_throws" in working.columns:
+            throws = working["pitcher_throws"].astype(str).str.strip().str.upper()
+            pa_vs_lhp = throws.eq("L").astype("float64")
+            pa_vs_rhp = throws.eq("R").astype("float64")
+
+        terminal = pd.DataFrame(
+            {
+                entity_id_col: working[entity_id_col].astype(str),
+                date_col: pd.to_datetime(working[date_col], errors="coerce"),
+                "game_pk": working["game_pk"],
+                "plate_appearances": 1.0,
+                "hits": hit_flag,
+                "total_bases": total_bases,
+                "walks": walk_flag,
+                "strikeouts": strikeout_flag,
+                "hard_hit_events": hard_hit_events,
+                "pa_vs_lhp": pa_vs_lhp,
+                "pa_vs_rhp": pa_vs_rhp,
+                "is_regular_season": working["is_regular_season"].astype(bool),
+                "pa_terminal_dedup_applied": working[
+                    "pa_terminal_dedup_applied"
+                ].astype(bool),
+            }
+        )
+        batter_game = (
+            terminal.groupby([entity_id_col, date_col, "game_pk"], dropna=False)
+            .agg(
+                {
+                    "plate_appearances": "sum",
+                    "hits": "sum",
+                    "total_bases": "sum",
+                    "walks": "sum",
+                    "strikeouts": "sum",
+                    "hard_hit_events": "sum",
+                    "pa_vs_lhp": "sum",
+                    "pa_vs_rhp": "sum",
+                    "is_regular_season": "max",
+                    "pa_terminal_dedup_applied": "max",
+                }
+            )
+            .reset_index()
+        )
+        working = (
+            batter_game.groupby([entity_id_col, date_col], dropna=False)
+            .agg(
+                {
+                    "plate_appearances": "sum",
+                    "hits": "sum",
+                    "total_bases": "sum",
+                    "walks": "sum",
+                    "strikeouts": "sum",
+                    "hard_hit_events": "sum",
+                    "pa_vs_lhp": "sum",
+                    "pa_vs_rhp": "sum",
+                    "is_regular_season": "max",
+                    "pa_terminal_dedup_applied": "max",
+                }
+            )
+            .reset_index()
+        )
+    else:
+        for column in (
+            "plate_appearances",
+            "hits",
+            "total_bases",
+            "walks",
+            "strikeouts",
+            "pa_vs_lhp",
+            "pa_vs_rhp",
+        ):
+            if column not in working.columns:
+                working[column] = 0.0
+            working[column] = pd.to_numeric(working[column], errors="coerce").fillna(
+                0.0
+            )
+        if "hard_hit_events" in working.columns:
+            working["hard_hit_events"] = _coerce_numeric(working, "hard_hit_events")
+        elif "hard_hit_rate" in working.columns:
+            working["hard_hit_events"] = _coerce_numeric(
+                working, "hard_hit_rate"
+            ) * _coerce_numeric(working, "plate_appearances").clip(lower=0.0)
+        else:
+            working["hard_hit_events"] = 0.0
+        working = (
+            working.groupby([entity_id_col, date_col], dropna=False)
+            .agg(
+                {
+                    "plate_appearances": "sum",
+                    "hits": "sum",
+                    "total_bases": "sum",
+                    "walks": "sum",
+                    "strikeouts": "sum",
+                    "hard_hit_events": "sum",
+                    "pa_vs_lhp": "sum",
+                    "pa_vs_rhp": "sum",
+                    "is_regular_season": "max",
+                    "pa_terminal_dedup_applied": "max",
+                }
+            )
+            .reset_index()
+        )
+
+    for column in (
+        "plate_appearances",
+        "hits",
+        "total_bases",
+        "walks",
+        "strikeouts",
+        "hard_hit_events",
+        "pa_vs_lhp",
+        "pa_vs_rhp",
+    ):
+        working[column] = pd.to_numeric(working[column], errors="coerce").fillna(0.0)
+
+    invalid = (
+        working["plate_appearances"].lt(0.0)
+        | working["hits"].lt(0.0)
+        | working["hits"].gt(working["plate_appearances"])
+    )
+    working["qa_invalid_row_flag"] = invalid.astype(bool)
+    working["plate_appearances"] = working["plate_appearances"].clip(lower=0.0)
+    working["hits"] = working["hits"].clip(lower=0.0)
+    working["hits"] = working[["hits", "plate_appearances"]].min(axis=1)
+    working["hard_hit_events"] = working["hard_hit_events"].clip(lower=0.0)
+    working["hard_hit_rate"] = (
+        working["hard_hit_events"] / working["plate_appearances"].replace(0.0, pd.NA)
+    ).fillna(0.0)
+    working["season"] = pd.to_datetime(working[date_col], errors="coerce").dt.year
+    return working.sort_values([entity_id_col, date_col], kind="stable").reset_index(
+        drop=True
+    )
 
 
 def build_player_season_snapshots(
@@ -102,6 +361,19 @@ def build_player_season_snapshots(
         entity_id_col=entity_id_col,
         date_col=date_col,
     )
+    league_hit_rate_prior = 0.0
+    pa_total = (
+        pd.to_numeric(engineered.get("plate_appearances", 0.0), errors="coerce")
+        .fillna(0.0)
+        .sum()
+    )
+    if pa_total > 0.0:
+        hit_total = (
+            pd.to_numeric(engineered.get("hits", 0.0), errors="coerce")
+            .fillna(0.0)
+            .sum()
+        )
+        league_hit_rate_prior = float(hit_total / pa_total)
     feature_columns = _snapshot_feature_columns(engineered)
     frequency = _normalize_anchor_frequency(snapshot_anchor_frequency)
 
@@ -128,7 +400,7 @@ def build_player_season_snapshots(
                 )
                 future = season_frame[
                     (season_frame[entity_id_col] == entity)
-                    & (season_frame[date_col] > anchor_date)
+                    & (season_frame[date_col] >= anchor_date)
                 ].copy()
 
                 target_future = pd.to_numeric(
@@ -148,8 +420,26 @@ def build_player_season_snapshots(
                     f"season_to_date_{target_col}": float(target_history.sum()),
                     f"target_rest_of_season_{target_col}": float(target_future.sum()),
                     "season_to_date_pa": float(pa_history.sum()),
+                    "season_to_date_plate_appearances": float(pa_history.sum()),
                     "snapshot_games_played": int(len(entity_history)),
                 }
+                alpha = 25.0
+                roll_pa_30 = float(
+                    pd.to_numeric(
+                        latest.get("roll_30_plate_appearances", 0.0), errors="coerce"
+                    )
+                )
+                roll_hits_30 = float(
+                    pd.to_numeric(latest.get("roll_30_hits", 0.0), errors="coerce")
+                )
+                std_hits = float(target_history.sum())
+                std_pa = float(pa_history.sum())
+                row["smoothed_hit_rate_rolling_30"] = (
+                    roll_hits_30 + (alpha * league_hit_rate_prior)
+                ) / max(roll_pa_30 + alpha, 1.0)
+                row["smoothed_hit_rate_season_to_date"] = (
+                    std_hits + (alpha * league_hit_rate_prior)
+                ) / max(std_pa + alpha, 1.0)
                 for column in feature_columns:
                     row[column] = float(
                         pd.to_numeric(latest.get(column, 0.0), errors="coerce")

--- a/src/fantasy/adapters/mlb/datasets.py
+++ b/src/fantasy/adapters/mlb/datasets.py
@@ -1,0 +1,173 @@
+"""Dataset builders for Phase 1.5 MLB season-horizon projection snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+from src.fantasy.adapters.mlb.feature_engineering import add_phase15_rolling_features
+
+SNAPSHOT_FEATURE_PREFIXES: tuple[str, ...] = (
+    "roll_",
+    "games_played_",
+    "pa_per_game_",
+)
+
+
+def _normalize_anchor_frequency(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"weekly", "daily"}:
+        return "weekly"
+    return normalized
+
+
+def _build_anchor_dates(
+    season_dates: pd.Series,
+    *,
+    frequency: str,
+) -> list[pd.Timestamp]:
+    if season_dates.empty:
+        return []
+    minimum = pd.Timestamp(season_dates.min()).normalize()
+    maximum = pd.Timestamp(season_dates.max()).normalize()
+    if frequency == "daily":
+        return list(pd.date_range(minimum, maximum, freq="D"))
+    return list(pd.date_range(minimum, maximum, freq="7D"))
+
+
+def _snapshot_feature_columns(frame: pd.DataFrame) -> list[str]:
+    return [
+        column
+        for column in frame.columns
+        if column.startswith(SNAPSHOT_FEATURE_PREFIXES)
+        or column in {"days_since_last_game", "hard_hit_rate"}
+    ]
+
+
+def build_player_season_snapshots(
+    frame: pd.DataFrame,
+    *,
+    entity_id_col: str,
+    date_col: str,
+    target_col: str,
+    snapshot_min_games: int = 5,
+    snapshot_anchor_frequency: str = "weekly",
+) -> pd.DataFrame:
+    """Build `(player, season, anchor)` snapshots with rest-of-season labels.
+
+    Args:
+        frame: Batter-game frame with base metric columns.
+        entity_id_col: Entity id column.
+        date_col: Date column.
+        target_col: Count metric target name.
+        snapshot_min_games: Minimum prior games required at anchor.
+        snapshot_anchor_frequency: One of `weekly` or `daily`.
+
+    Returns:
+        Snapshot DataFrame with leakage-safe features and rest-of-season target.
+    """
+
+    if frame.empty:
+        return pd.DataFrame()
+
+    working = frame.copy()
+    if entity_id_col not in working.columns or date_col not in working.columns:
+        return pd.DataFrame()
+
+    working[entity_id_col] = working[entity_id_col].astype(str).str.strip()
+    working = working[working[entity_id_col].ne("")].copy()
+    working[date_col] = pd.to_datetime(working[date_col], errors="coerce")
+    working = working.dropna(subset=[date_col]).copy()
+    if working.empty:
+        return pd.DataFrame()
+
+    if "season" not in working.columns:
+        working["season"] = working[date_col].dt.year
+    working["season"] = pd.to_numeric(working["season"], errors="coerce").astype(
+        "Int64"
+    )
+
+    if target_col not in working.columns:
+        working[target_col] = 0.0
+    working[target_col] = pd.to_numeric(working[target_col], errors="coerce").fillna(
+        0.0
+    )
+    working["plate_appearances"] = pd.to_numeric(
+        working.get("plate_appearances", 0.0), errors="coerce"
+    ).fillna(0.0)
+
+    engineered = add_phase15_rolling_features(
+        working,
+        entity_id_col=entity_id_col,
+        date_col=date_col,
+    )
+    feature_columns = _snapshot_feature_columns(engineered)
+    frequency = _normalize_anchor_frequency(snapshot_anchor_frequency)
+
+    rows: list[dict[str, object]] = []
+    for season, season_frame in engineered.groupby("season", dropna=True):
+        if pd.isna(season):
+            continue
+        season_dates = pd.to_datetime(season_frame[date_col], errors="coerce").dropna()
+        for anchor_date in _build_anchor_dates(season_dates, frequency=frequency):
+            history = season_frame[season_frame[date_col] < anchor_date].copy()
+            if history.empty:
+                continue
+            grouped_history = history.groupby(entity_id_col, dropna=False)
+            game_counts = grouped_history[date_col].size()
+            eligible_entities: Iterable[object] = game_counts[
+                game_counts >= int(max(snapshot_min_games, 1))
+            ].index
+            for entity in eligible_entities:
+                entity_history = history[history[entity_id_col] == entity].copy()
+                if entity_history.empty:
+                    continue
+                latest = (
+                    entity_history.sort_values(date_col, kind="stable").tail(1).iloc[0]
+                )
+                future = season_frame[
+                    (season_frame[entity_id_col] == entity)
+                    & (season_frame[date_col] > anchor_date)
+                ].copy()
+
+                target_future = pd.to_numeric(
+                    future.get(target_col, 0.0), errors="coerce"
+                ).fillna(0.0)
+                target_history = pd.to_numeric(
+                    entity_history.get(target_col, 0.0), errors="coerce"
+                ).fillna(0.0)
+                pa_history = pd.to_numeric(
+                    entity_history.get("plate_appearances", 0.0), errors="coerce"
+                ).fillna(0.0)
+
+                row: dict[str, object] = {
+                    "entity_id": str(entity),
+                    "season": int(season),
+                    "anchor_date": pd.Timestamp(anchor_date).date().isoformat(),
+                    f"season_to_date_{target_col}": float(target_history.sum()),
+                    f"target_rest_of_season_{target_col}": float(target_future.sum()),
+                    "season_to_date_pa": float(pa_history.sum()),
+                    "snapshot_games_played": int(len(entity_history)),
+                }
+                for column in feature_columns:
+                    row[column] = float(
+                        pd.to_numeric(latest.get(column, 0.0), errors="coerce")
+                    )
+                rows.append(row)
+
+    if not rows:
+        return pd.DataFrame()
+
+    snapshot = pd.DataFrame(rows)
+    snapshot = snapshot.sort_values(
+        ["season", "anchor_date", "entity_id"], kind="stable"
+    )
+    snapshot = snapshot.reset_index(drop=True)
+
+    numeric_columns = [
+        col for col in snapshot.columns if col not in {"entity_id", "anchor_date"}
+    ]
+    for column in numeric_columns:
+        snapshot[column] = pd.to_numeric(snapshot[column], errors="coerce").fillna(0.0)
+    return snapshot

--- a/src/fantasy/adapters/mlb/feature_engineering.py
+++ b/src/fantasy/adapters/mlb/feature_engineering.py
@@ -1,0 +1,107 @@
+"""Phase 1.5 leakage-safe feature engineering for MLB batter projections."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+ROLLING_WINDOWS: tuple[int, ...] = (7, 14, 30)
+ROLL_BASE_COLUMNS: tuple[str, ...] = (
+    "plate_appearances",
+    "hits",
+    "total_bases",
+    "walks",
+    "strikeouts",
+    "hard_hit_events",
+)
+
+
+def _safe_ratio(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
+    num = pd.to_numeric(numerator, errors="coerce").fillna(0.0)
+    den = pd.to_numeric(denominator, errors="coerce").fillna(0.0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        values = np.where(den > 0.0, num / den, 0.0)
+    return pd.Series(values, index=numerator.index, dtype="float64")
+
+
+def add_phase15_rolling_features(
+    frame: pd.DataFrame,
+    *,
+    entity_id_col: str,
+    date_col: str,
+) -> pd.DataFrame:
+    """Add shifted rolling features that only use pre-anchor observations.
+
+    Args:
+        frame: Batter-game frame.
+        entity_id_col: Entity id column.
+        date_col: Date column.
+
+    Returns:
+        DataFrame with added leakage-safe rolling features.
+    """
+
+    if frame.empty:
+        return frame.copy()
+
+    engineered = frame.copy()
+    engineered[date_col] = pd.to_datetime(engineered[date_col], errors="coerce")
+    engineered = engineered.sort_values([entity_id_col, date_col], kind="stable")
+
+    for base_column in ROLL_BASE_COLUMNS:
+        if base_column not in engineered.columns:
+            engineered[base_column] = 0.0
+        engineered[base_column] = pd.to_numeric(
+            engineered[base_column], errors="coerce"
+        ).fillna(0.0)
+
+    grouped = engineered.groupby(entity_id_col, dropna=False)
+    for window in ROLLING_WINDOWS:
+        for base_column in ROLL_BASE_COLUMNS:
+            column_name = f"roll_{window}_{base_column}"
+            engineered[column_name] = grouped[base_column].transform(
+                lambda series: series.shift(1).rolling(window, min_periods=1).mean()
+            )
+            engineered[column_name] = pd.to_numeric(
+                engineered[column_name], errors="coerce"
+            ).fillna(0.0)
+
+        plate_col = f"roll_{window}_plate_appearances"
+        engineered[f"roll_{window}_hit_rate"] = _safe_ratio(
+            engineered[f"roll_{window}_hits"], engineered[plate_col]
+        )
+        engineered[f"roll_{window}_walk_rate"] = _safe_ratio(
+            engineered[f"roll_{window}_walks"], engineered[plate_col]
+        )
+        engineered[f"roll_{window}_strikeout_rate"] = _safe_ratio(
+            engineered[f"roll_{window}_strikeouts"], engineered[plate_col]
+        )
+        engineered[f"roll_{window}_slugging_proxy"] = _safe_ratio(
+            engineered[f"roll_{window}_total_bases"], engineered[plate_col]
+        )
+        engineered[f"roll_{window}_hard_hit_rate"] = _safe_ratio(
+            engineered[f"roll_{window}_hard_hit_events"], engineered[plate_col]
+        )
+
+    date_series = pd.to_datetime(engineered[date_col], errors="coerce")
+    prev_game = grouped[date_col].shift(1)
+    prev_game = pd.to_datetime(prev_game, errors="coerce")
+    engineered["days_since_last_game"] = (
+        (date_series - prev_game).dt.days.fillna(365.0).clip(lower=0.0)
+    )
+
+    for window in (14, 30):
+        engineered[f"games_played_last_{window}"] = grouped[
+            "plate_appearances"
+        ].transform(
+            lambda series: series.shift(1).rolling(window, min_periods=1).count()
+        )
+        engineered[f"games_played_last_{window}"] = pd.to_numeric(
+            engineered[f"games_played_last_{window}"], errors="coerce"
+        ).fillna(0.0)
+        engineered[f"pa_per_game_last_{window}"] = _safe_ratio(
+            engineered[f"roll_{window}_plate_appearances"],
+            engineered[f"games_played_last_{window}"],
+        )
+
+    return engineered

--- a/src/fantasy/adapters/mlb/feature_engineering.py
+++ b/src/fantasy/adapters/mlb/feature_engineering.py
@@ -13,6 +13,8 @@ ROLL_BASE_COLUMNS: tuple[str, ...] = (
     "walks",
     "strikeouts",
     "hard_hit_events",
+    "pa_vs_lhp",
+    "pa_vs_rhp",
 )
 
 
@@ -82,6 +84,12 @@ def add_phase15_rolling_features(
         engineered[f"roll_{window}_hard_hit_rate"] = _safe_ratio(
             engineered[f"roll_{window}_hard_hit_events"], engineered[plate_col]
         )
+        engineered[f"roll_{window}_pa_vs_lhp_share"] = _safe_ratio(
+            engineered[f"roll_{window}_pa_vs_lhp"], engineered[plate_col]
+        )
+        engineered[f"roll_{window}_pa_vs_rhp_share"] = _safe_ratio(
+            engineered[f"roll_{window}_pa_vs_rhp"], engineered[plate_col]
+        )
 
     date_series = pd.to_datetime(engineered[date_col], errors="coerce")
     prev_game = grouped[date_col].shift(1)
@@ -103,5 +111,28 @@ def add_phase15_rolling_features(
             engineered[f"roll_{window}_plate_appearances"],
             engineered[f"games_played_last_{window}"],
         )
+
+    engineered["team_games_seen_last_30"] = pd.to_numeric(
+        engineered.get("games_played_last_30", 0.0), errors="coerce"
+    ).fillna(0.0)
+    engineered["player_game_share_last_30"] = _safe_ratio(
+        engineered["games_played_last_30"], pd.Series(30.0, index=engineered.index)
+    ).clip(lower=0.0, upper=1.0)
+
+    def _shifted_consecutive_streak(series: pd.Series) -> pd.Series:
+        games = pd.to_numeric(series, errors="coerce").fillna(0.0).gt(0.0)
+        output = []
+        streak = 0
+        for played in games:
+            output.append(float(streak))
+            if played:
+                streak += 1
+            else:
+                streak = 0
+        return pd.Series(output, index=series.index, dtype="float64")
+
+    engineered["recent_consecutive_games_played"] = grouped[
+        "plate_appearances"
+    ].transform(_shifted_consecutive_streak)
 
     return engineered

--- a/src/fantasy/adapters/mlb/features.py
+++ b/src/fantasy/adapters/mlb/features.py
@@ -38,6 +38,24 @@ _BASE_FEATURE_COLUMNS: tuple[str, ...] = (
     "slugging_proxy",
 )
 
+DIRECT_COUNT_METRICS: tuple[str, ...] = (
+    "plate_appearances",
+    "hits",
+    "total_bases",
+    "walks",
+    "strikeouts",
+    "pa_vs_lhp",
+    "pa_vs_rhp",
+    "hard_hit_events",
+)
+
+DERIVED_RATE_INPUTS: dict[str, tuple[str, str]] = {
+    "hit_rate": ("hits", "plate_appearances"),
+    "walk_rate": ("walks", "plate_appearances"),
+    "strikeout_rate": ("strikeouts", "plate_appearances"),
+    "slugging_proxy": ("total_bases", "plate_appearances"),
+}
+
 _TARGET_LEAKAGE_BLOCKLIST: dict[str, tuple[str, ...]] = {
     "plate_appearances": (
         "plate_appearances",
@@ -155,3 +173,16 @@ def model_feature_columns_for_metric(metric_id: str) -> list[str]:
     metric_key = metric_id.strip().lower()
     blocked = set(_TARGET_LEAKAGE_BLOCKLIST.get(metric_key, (metric_key,)))
     return [column for column in _BASE_FEATURE_COLUMNS if column not in blocked]
+
+
+def is_derived_rate_metric(metric_id: str) -> bool:
+    """Return whether a metric is derived from count predictions."""
+
+    return metric_id.strip().lower() in DERIVED_RATE_INPUTS
+
+
+def rate_metric_inputs(metric_id: str) -> tuple[str, str]:
+    """Return `(numerator_metric, denominator_metric)` for derived rate metrics."""
+
+    metric_key = metric_id.strip().lower()
+    return DERIVED_RATE_INPUTS[metric_key]

--- a/src/fantasy/adapters/mlb/priors.py
+++ b/src/fantasy/adapters/mlb/priors.py
@@ -1,0 +1,92 @@
+"""Pybaseball seasonal-prior helpers for Phase 1.5 MLB projection features."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pandas as pd
+
+from src.utils.io import read_csv
+
+
+def load_cached_priors(cache_path: str) -> pd.DataFrame:
+    """Load cached priors table from CSV/Parquet path."""
+
+    return read_csv(cache_path)
+
+
+def attach_priors_to_snapshots(
+    *,
+    snapshots: pd.DataFrame,
+    priors: pd.DataFrame,
+    prior_columns: Sequence[str],
+) -> pd.DataFrame:
+    """Join priors to snapshot rows with deterministic league-median fallback.
+
+    Args:
+        snapshots: Snapshot rows containing `fg_id` and optional `season`.
+        priors: Prior table keyed by `fg_id` and optional `season`.
+        prior_columns: Prior numeric columns to project onto snapshots.
+
+    Returns:
+        Snapshot frame with prior columns and `prior_imputed_flag`.
+    """
+
+    if snapshots.empty:
+        result = snapshots.copy()
+        result["prior_imputed_flag"] = pd.Series(dtype="int64")
+        return result
+
+    result = snapshots.copy()
+    if priors.empty:
+        for column in prior_columns:
+            result[column] = 0.0
+        result["prior_imputed_flag"] = 1
+        return result
+
+    median_values: dict[str, float] = {}
+    for column in prior_columns:
+        source = pd.to_numeric(
+            priors.get(column, pd.Series(dtype="float64")), errors="coerce"
+        )
+        median = float(source.median()) if not source.dropna().empty else 0.0
+        median_values[column] = median
+
+    if "fg_id" not in result.columns or "fg_id" not in priors.columns:
+        merged = result.copy()
+        for column in prior_columns:
+            merged[column] = median_values[column]
+        merged["prior_imputed_flag"] = 1
+        return merged
+
+    merge_on: list[str] = ["fg_id"]
+    if "season" in result.columns and "season" in priors.columns:
+        merge_on.append("season")
+
+    prior_lookup = priors.copy()
+    for column in prior_columns:
+        prior_lookup[column] = pd.to_numeric(
+            prior_lookup.get(column, pd.Series(dtype="float64")),
+            errors="coerce",
+        )
+    prior_lookup = (
+        prior_lookup[merge_on + list(prior_columns)]
+        .groupby(merge_on, dropna=False, as_index=False)
+        .median(numeric_only=True)
+    )
+
+    merged = result.merge(
+        prior_lookup,
+        on=merge_on,
+        how="left",
+        suffixes=("", "_prior"),
+    )
+
+    missing_mask = pd.Series(False, index=merged.index)
+    for column in prior_columns:
+        numeric = pd.to_numeric(merged[column], errors="coerce")
+        missing_mask = missing_mask | numeric.isna()
+        merged[column] = numeric.fillna(median_values[column]).astype("float64")
+
+    merged["prior_imputed_flag"] = missing_mask.astype("int64")
+    return merged

--- a/src/fantasy/adapters/mlb/projection_adapter.py
+++ b/src/fantasy/adapters/mlb/projection_adapter.py
@@ -10,6 +10,10 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from src.fantasy.adapters.mlb.datasets import (
+    build_hits_pa_training_view,
+    build_player_season_snapshots,
+)
 from src.fantasy.adapters.mlb.features import (
     is_derived_rate_metric,
     model_feature_columns_for_metric,
@@ -19,6 +23,7 @@ from src.fantasy.adapters.mlb.features import (
 from src.fantasy.adapters.mlb.uncertainty import (
     availability_confidence_by_entity,
     summarize_empirical_uncertainty,
+    summarize_hit_rate_uncertainty_from_counts,
 )
 from src.fantasy.core.contracts import ContestConfig
 from src.mlb.models.registry import get_model_spec
@@ -40,6 +45,45 @@ NEUTRAL_OUTPUT_COLUMNS: tuple[str, ...] = (
     "availability_confidence",
     "source_model_version",
     "source_snapshot_id",
+)
+
+SNAPSHOT_COUNT_TARGETS: frozenset[str] = frozenset({"hits", "plate_appearances"})
+PA_SNAPSHOT_FEATURES: tuple[str, ...] = (
+    "roll_7_plate_appearances",
+    "roll_14_plate_appearances",
+    "roll_30_plate_appearances",
+    "games_played_last_14",
+    "games_played_last_30",
+    "pa_per_game_last_14",
+    "pa_per_game_last_30",
+    "days_since_last_game",
+    "team_games_seen_last_30",
+    "player_game_share_last_30",
+    "recent_consecutive_games_played",
+    "roll_30_pa_vs_lhp_share",
+    "roll_30_pa_vs_rhp_share",
+    "season_to_date_pa",
+    "snapshot_games_played",
+)
+HITS_SNAPSHOT_FEATURES: tuple[str, ...] = PA_SNAPSHOT_FEATURES + (
+    "roll_7_hits",
+    "roll_14_hits",
+    "roll_30_hits",
+    "roll_7_hit_rate",
+    "roll_14_hit_rate",
+    "roll_30_hit_rate",
+    "roll_7_hard_hit_rate",
+    "roll_14_hard_hit_rate",
+    "roll_30_hard_hit_rate",
+    "roll_7_total_bases",
+    "roll_14_total_bases",
+    "roll_30_total_bases",
+    "roll_7_slugging_proxy",
+    "roll_14_slugging_proxy",
+    "roll_30_slugging_proxy",
+    "smoothed_hit_rate_rolling_30",
+    "smoothed_hit_rate_season_to_date",
+    "season_to_date_hits",
 )
 
 
@@ -68,12 +112,25 @@ class MlbProjectionAdapterConfig:
     )
     model_selection_primary_metric: str = "mae"
     model_selection_max_trials_per_model: int = 1
+    selection_min_delta_mae: float = 0.0
     pybaseball_priors_enabled: bool = False
     pybaseball_priors_cache_path: str = ""
     pybaseball_priors_seasons: tuple[int, ...] = ()
     pybaseball_priors_refresh: bool = False
     uncertainty_residual_bucket_col: str = "season_to_date_pa"
     uncertainty_bucket_edges: tuple[float, ...] = (0.0, 100.0, 250.0, 450.0, 700.0)
+    hit_rate_residual_scale_global: float = 1.0
+    hit_rate_residual_scale_by_bucket: dict[str, float] | None = None
+    coverage_target: float = 0.80
+    calibration_objective: str = "coverage_width_tradeoff"
+    min_bucket_residual_count: int = 100
+    regular_season_only: bool = True
+    require_batter_pa_dedup: bool = True
+    count_nonnegative_constraints: bool = True
+    hits_leq_pa_constraint: bool = True
+    hit_rate_derivation_source: str = "counts_only"
+    evaluation_primary_metric_focus: str = "hit_rate"
+    hit_rate_uncertainty_draws: int = 500
     source_snapshot_id: str | None = None
 
     @classmethod
@@ -86,6 +143,18 @@ class MlbProjectionAdapterConfig:
             effective.update(phase15)
         else:
             effective = dict(payload)
+        cleaning = effective.get("data_cleaning", {})
+        modeling = effective.get("modeling", {})
+        evaluation = effective.get("evaluation", {})
+        uncertainty = effective.get("uncertainty", {})
+        if not isinstance(cleaning, dict):
+            cleaning = {}
+        if not isinstance(modeling, dict):
+            modeling = {}
+        if not isinstance(evaluation, dict):
+            evaluation = {}
+        if not isinstance(uncertainty, dict):
+            uncertainty = {}
 
         candidates_raw = effective.get("model_selection_candidates")
         if isinstance(candidates_raw, list):
@@ -107,6 +176,17 @@ class MlbProjectionAdapterConfig:
             bucket_edges = tuple(float(value) for value in edges_raw)
         else:
             bucket_edges = (0.0, 100.0, 250.0, 450.0, 700.0)
+        scale_by_bucket_raw = uncertainty.get(
+            "hit_rate_residual_scale_by_bucket",
+            effective.get("hit_rate_residual_scale_by_bucket", {}),
+        )
+        if isinstance(scale_by_bucket_raw, dict):
+            scale_by_bucket = {
+                str(bucket): float(scale)
+                for bucket, scale in scale_by_bucket_raw.items()
+            }
+        else:
+            scale_by_bucket = {}
         training_paths_raw = effective.get("training_data_paths")
         if isinstance(training_paths_raw, list):
             training_data_paths = tuple(str(path) for path in training_paths_raw)
@@ -148,6 +228,12 @@ class MlbProjectionAdapterConfig:
             model_selection_max_trials_per_model=int(
                 effective.get("model_selection_max_trials_per_model", 1)
             ),
+            selection_min_delta_mae=float(
+                modeling.get(
+                    "selection_min_delta_mae",
+                    effective.get("selection_min_delta_mae", 0.0),
+                )
+            ),
             pybaseball_priors_enabled=bool(
                 effective.get("pybaseball_priors_enabled", False)
             ),
@@ -162,12 +248,90 @@ class MlbProjectionAdapterConfig:
                 effective.get("uncertainty_residual_bucket_col", "season_to_date_pa")
             ),
             uncertainty_bucket_edges=bucket_edges,
+            hit_rate_residual_scale_global=float(
+                uncertainty.get(
+                    "hit_rate_residual_scale_global",
+                    effective.get("hit_rate_residual_scale_global", 1.0),
+                )
+            ),
+            hit_rate_residual_scale_by_bucket=scale_by_bucket,
+            coverage_target=float(
+                uncertainty.get(
+                    "coverage_target",
+                    effective.get("coverage_target", 0.80),
+                )
+            ),
+            calibration_objective=str(
+                uncertainty.get(
+                    "calibration_objective",
+                    effective.get("calibration_objective", "coverage_width_tradeoff"),
+                )
+            ),
+            min_bucket_residual_count=int(
+                uncertainty.get(
+                    "min_bucket_residual_count",
+                    effective.get("min_bucket_residual_count", 100),
+                )
+            ),
+            regular_season_only=bool(
+                cleaning.get(
+                    "regular_season_only",
+                    effective.get("regular_season_only", True),
+                )
+            ),
+            require_batter_pa_dedup=bool(
+                cleaning.get(
+                    "require_batter_pa_dedup",
+                    effective.get("require_batter_pa_dedup", True),
+                )
+            ),
+            count_nonnegative_constraints=bool(
+                modeling.get(
+                    "count_nonnegative_constraints",
+                    effective.get("count_nonnegative_constraints", True),
+                )
+            ),
+            hits_leq_pa_constraint=bool(
+                modeling.get(
+                    "hits_leq_pa_constraint",
+                    effective.get("hits_leq_pa_constraint", True),
+                )
+            ),
+            hit_rate_derivation_source=str(
+                modeling.get(
+                    "hit_rate_derivation_source",
+                    effective.get("hit_rate_derivation_source", "counts_only"),
+                )
+            ),
+            evaluation_primary_metric_focus=str(
+                evaluation.get(
+                    "primary_metric_focus",
+                    effective.get("evaluation_primary_metric_focus", "hit_rate"),
+                )
+            ),
+            hit_rate_uncertainty_draws=int(
+                modeling.get(
+                    "hit_rate_uncertainty_draws",
+                    effective.get("hit_rate_uncertainty_draws", 500),
+                )
+            ),
             source_snapshot_id=(
                 str(effective["source_snapshot_id"])
                 if effective.get("source_snapshot_id") is not None
                 else None
             ),
         )
+
+
+@dataclass(frozen=True, slots=True)
+class CountProjectionDetails:
+    """Count projection payload with uncertainty calibration metadata."""
+
+    mean_by_entity: pd.Series
+    residuals: pd.Series
+    model_name: str
+    bucket_by_entity: pd.Series
+    residuals_by_bucket: dict[str, pd.Series]
 
 
 class MlbSeasonProjectionAdapter:
@@ -212,21 +376,28 @@ class MlbSeasonProjectionAdapter:
                 metric_id=denominator,
                 config=config,
                 source=source,
-            ).clip(lower=0.0)
-            _, numerator_residuals, numerator_model_name = (
-                self._predict_count_projection_details(
-                    metric_id=numerator,
-                    config=config,
-                    source=source,
-                )
             )
-            _, denominator_residuals, denominator_model_name = (
-                self._predict_count_projection_details(
-                    metric_id=denominator,
-                    config=config,
-                    source=source,
-                )
+            numerator_details = self._predict_count_projection_result(
+                metric_id=numerator,
+                config=config,
+                source=source,
             )
+            denominator_details = self._predict_count_projection_result(
+                metric_id=denominator,
+                config=config,
+                source=source,
+            )
+            if self.adapter_config.count_nonnegative_constraints:
+                numerator_mean = numerator_mean.clip(lower=0.0)
+                denominator_mean = denominator_mean.clip(lower=0.0)
+            if (
+                self.adapter_config.hits_leq_pa_constraint
+                and numerator == "hits"
+                and denominator == "plate_appearances"
+            ):
+                numerator_mean = pd.concat(
+                    [numerator_mean, denominator_mean], axis=1
+                ).min(axis=1)
             entity_index = numerator_mean.index.union(denominator_mean.index)
             numerator_mean = numerator_mean.reindex(entity_index).fillna(0.0)
             denominator_mean = denominator_mean.reindex(entity_index).fillna(0.0)
@@ -237,33 +408,57 @@ class MlbSeasonProjectionAdapter:
                     / denominator_mean.to_numpy(dtype="float64"),
                     0.0,
                 )
-            mean_by_entity = pd.Series(values, index=entity_index, dtype="float64")
-            model_name = numerator_model_name
-            if denominator_model_name != numerator_model_name:
-                model_name = f"{numerator_model_name}+{denominator_model_name}"
-            residuals = numerator_residuals
-            if residuals.empty:
-                residuals = denominator_residuals
+            mean_by_entity = pd.Series(
+                values, index=entity_index, dtype="float64"
+            ).clip(lower=0.0, upper=1.0)
+            model_name = numerator_details.model_name
+            if denominator_details.model_name != numerator_details.model_name:
+                model_name = (
+                    f"{numerator_details.model_name}+{denominator_details.model_name}"
+                )
             sample_sizes = (
                 sample_sizes.reindex(entity_index).fillna(1.0).clip(lower=1.0)
             )
-        else:
-            mean_by_entity, residuals, model_name = (
-                self._predict_count_projection_details(
-                    metric_id=self.metric_id,
-                    config=config,
-                    source=source,
-                )
+            uncertainty = summarize_hit_rate_uncertainty_from_counts(
+                hit_mean_by_entity=numerator_mean,
+                pa_mean_by_entity=denominator_mean,
+                sample_size_by_entity=sample_sizes,
+                hit_residuals=numerator_details.residuals,
+                pa_residuals=denominator_details.residuals,
+                seed=self.adapter_config.seed,
+                draws=max(self.adapter_config.hit_rate_uncertainty_draws, 100),
+                residual_scale_global=self.adapter_config.hit_rate_residual_scale_global,
+                residual_scale_by_bucket=self.adapter_config.hit_rate_residual_scale_by_bucket,
+                bucket_by_entity=denominator_details.bucket_by_entity.reindex(
+                    entity_index
+                ).fillna("default"),
+                hit_residuals_by_bucket=numerator_details.residuals_by_bucket,
+                pa_residuals_by_bucket=denominator_details.residuals_by_bucket,
+                min_bucket_residual_count=self.adapter_config.min_bucket_residual_count,
             )
+        else:
+            details = self._predict_count_projection_result(
+                metric_id=self.metric_id,
+                config=config,
+                source=source,
+            )
+            mean_by_entity = details.mean_by_entity
+            residuals = details.residuals
+            model_name = details.model_name
+            if self.adapter_config.count_nonnegative_constraints:
+                mean_by_entity = mean_by_entity.clip(lower=0.0)
             sample_sizes = (
                 sample_sizes.reindex(mean_by_entity.index).fillna(1.0).clip(lower=1.0)
             )
-
-        uncertainty = summarize_empirical_uncertainty(
-            mean_by_entity=mean_by_entity,
-            sample_size_by_entity=sample_sizes,
-            residuals=residuals,
-        )
+            uncertainty = summarize_empirical_uncertainty(
+                mean_by_entity=mean_by_entity,
+                sample_size_by_entity=sample_sizes,
+                residuals=residuals,
+            )
+            if self.adapter_config.count_nonnegative_constraints:
+                uncertainty["p10"] = uncertainty["p10"].clip(lower=0.0)
+                uncertainty["p50"] = uncertainty["p50"].clip(lower=0.0)
+                uncertainty["p90"] = uncertainty["p90"].clip(lower=0.0)
         entity_id_col = self.adapter_config.entity_id_col
         availability = availability_confidence_by_entity(
             confidence_frame,
@@ -361,14 +556,12 @@ class MlbSeasonProjectionAdapter:
     ) -> pd.Series:
         """Predict season-horizon totals for a count-like metric."""
 
-        mean_by_entity, _residuals, _model_name = (
-            self._predict_count_projection_details(
-                metric_id=metric_id,
-                config=config,
-                source=source,
-            )
+        details = self._predict_count_projection_result(
+            metric_id=metric_id,
+            config=config,
+            source=source,
         )
-        return mean_by_entity
+        return details.mean_by_entity
 
     def _predict_count_projection_details(
         self,
@@ -377,7 +570,23 @@ class MlbSeasonProjectionAdapter:
         config: ContestConfig,
         source: pd.DataFrame,
     ) -> tuple[pd.Series, pd.Series, str]:
-        """Predict count totals with residuals and resolved model provenance."""
+        """Backward-compatible tuple projection details wrapper."""
+
+        details = self._predict_count_projection_result(
+            metric_id=metric_id,
+            config=config,
+            source=source,
+        )
+        return details.mean_by_entity, details.residuals, details.model_name
+
+    def _predict_count_projection_result(
+        self,
+        *,
+        metric_id: str,
+        config: ContestConfig,
+        source: pd.DataFrame,
+    ) -> CountProjectionDetails:
+        """Predict count totals with residual and bucket metadata."""
 
         window_start, window_end = self._resolve_window_for_metric(config, metric_id)
         context = self._build_projection_context(
@@ -393,6 +602,183 @@ class MlbSeasonProjectionAdapter:
         if pd.isna(train_cutoff):
             train_cutoff = feature_cutoff
         train_cutoff = min(pd.Timestamp(train_cutoff), pd.Timestamp(feature_cutoff))
+
+        if metric_id in SNAPSHOT_COUNT_TARGETS:
+            return self._predict_snapshot_count_projection_details(
+                metric_id=metric_id,
+                config=config,
+                source=source,
+                context=context,
+                train_cutoff=pd.Timestamp(train_cutoff),
+                feature_cutoff=pd.Timestamp(feature_cutoff),
+            )
+        return self._predict_count_projection_details_legacy(
+            metric_id=metric_id,
+            source=source,
+            context=context,
+            train_cutoff=pd.Timestamp(train_cutoff),
+            feature_cutoff=pd.Timestamp(feature_cutoff),
+        )
+
+    def _predict_snapshot_count_projection_details(
+        self,
+        *,
+        metric_id: str,
+        config: ContestConfig,
+        source: pd.DataFrame,
+        context: dict[str, Any],
+        train_cutoff: pd.Timestamp,
+        feature_cutoff: pd.Timestamp,
+    ) -> CountProjectionDetails:
+        """Predict season totals for snapshot-trained count targets."""
+
+        entity_id_col = self.adapter_config.entity_id_col
+        date_col = self.adapter_config.date_col
+        cleaned = build_hits_pa_training_view(
+            source,
+            entity_id_col=entity_id_col,
+            date_col=date_col,
+            regular_season_only=self.adapter_config.regular_season_only,
+            require_batter_pa_dedup=self.adapter_config.require_batter_pa_dedup,
+        )
+        if cleaned.empty:
+            return self._predict_count_projection_details_legacy(
+                metric_id=metric_id,
+                source=source,
+                context=context,
+                train_cutoff=train_cutoff,
+                feature_cutoff=feature_cutoff,
+            )
+
+        snapshots = build_player_season_snapshots(
+            cleaned,
+            entity_id_col=entity_id_col,
+            date_col=date_col,
+            target_col=metric_id,
+            snapshot_min_games=max(self.adapter_config.snapshot_min_games, 1),
+            snapshot_anchor_frequency=self.adapter_config.snapshot_anchor_frequency,
+        )
+        if snapshots.empty:
+            return self._predict_count_projection_details_legacy(
+                metric_id=metric_id,
+                source=source,
+                context=context,
+                train_cutoff=train_cutoff,
+                feature_cutoff=feature_cutoff,
+            )
+
+        snapshots["anchor_date"] = pd.to_datetime(
+            snapshots["anchor_date"], errors="coerce"
+        )
+        snapshots = snapshots.dropna(subset=["anchor_date"]).copy()
+        target_col = f"target_rest_of_season_{metric_id}"
+        if target_col not in snapshots.columns:
+            snapshots[target_col] = 0.0
+        snapshots[target_col] = pd.to_numeric(
+            snapshots[target_col], errors="coerce"
+        ).fillna(0.0)
+
+        train_frame = snapshots[snapshots["anchor_date"] <= train_cutoff].copy()
+        infer_frame = snapshots[snapshots["anchor_date"] <= feature_cutoff].copy()
+        if infer_frame.empty:
+            return self._predict_count_projection_details_legacy(
+                metric_id=metric_id,
+                source=source,
+                context=context,
+                train_cutoff=train_cutoff,
+                feature_cutoff=feature_cutoff,
+            )
+        else:
+            infer_frame = (
+                infer_frame.sort_values("anchor_date", kind="stable")
+                .groupby("entity_id", as_index=False)
+                .tail(1)
+                .copy()
+            )
+
+        features = list(
+            HITS_SNAPSHOT_FEATURES if metric_id == "hits" else PA_SNAPSHOT_FEATURES
+        )
+        for frame in (train_frame, infer_frame):
+            for column in features:
+                if column not in frame.columns:
+                    frame[column] = 0.0
+                frame[column] = pd.to_numeric(frame[column], errors="coerce").fillna(
+                    0.0
+                )
+            if target_col not in frame.columns:
+                frame[target_col] = 0.0
+            frame[target_col] = pd.to_numeric(
+                frame[target_col], errors="coerce"
+            ).fillna(0.0)
+            if "season_to_date_pa" not in frame.columns:
+                frame["season_to_date_pa"] = 0.0
+            if f"season_to_date_{metric_id}" not in frame.columns:
+                frame[f"season_to_date_{metric_id}"] = 0.0
+
+        train_payload = train_frame.loc[:, [*features, target_col]].copy()
+        infer_payload = infer_frame.loc[:, [*features]].copy()
+        try:
+            infer_prediction, residuals, model_name = self._apply_model(
+                train_frame=train_payload,
+                infer_frame=infer_payload,
+                target_col=target_col,
+                feature_columns=features,
+            )
+        except TypeError:
+            infer_prediction, residuals, model_name = self._apply_model(
+                train_frame=train_payload,
+                infer_frame=infer_payload,
+                target_col=target_col,
+            )
+        pred_remaining = pd.to_numeric(
+            infer_prediction.get("prediction", 0.0), errors="coerce"
+        ).fillna(0.0)
+        if self.adapter_config.count_nonnegative_constraints:
+            pred_remaining = pred_remaining.clip(lower=0.0)
+        season_to_date = pd.to_numeric(
+            infer_frame.get(f"season_to_date_{metric_id}", 0.0), errors="coerce"
+        ).fillna(0.0)
+        totals = (season_to_date + pred_remaining).astype("float64")
+        if self.adapter_config.count_nonnegative_constraints:
+            totals = totals.clip(lower=0.0)
+        mean_by_entity = pd.Series(
+            totals.to_numpy(dtype="float64"),
+            index=infer_frame["entity_id"].astype(str),
+            dtype="float64",
+        )
+        clean_residuals = (
+            pd.to_numeric(residuals, errors="coerce").dropna().astype("float64")
+        )
+        bucket_by_entity = self._bucket_labels_from_values(
+            pd.to_numeric(infer_frame.get("season_to_date_pa", 0.0), errors="coerce")
+            .fillna(0.0)
+            .set_axis(mean_by_entity.index)
+        )
+        residuals_by_bucket = self._build_residual_bank_by_bucket(
+            values=pd.to_numeric(
+                train_frame.get("season_to_date_pa", 0.0), errors="coerce"
+            ).fillna(0.0),
+            residuals=clean_residuals,
+        )
+        return CountProjectionDetails(
+            mean_by_entity=mean_by_entity,
+            residuals=clean_residuals,
+            model_name=str(model_name),
+            bucket_by_entity=bucket_by_entity,
+            residuals_by_bucket=residuals_by_bucket,
+        )
+
+    def _predict_count_projection_details_legacy(
+        self,
+        *,
+        metric_id: str,
+        source: pd.DataFrame,
+        context: dict[str, Any],
+        train_cutoff: pd.Timestamp,
+        feature_cutoff: pd.Timestamp,
+    ) -> CountProjectionDetails:
+        """Legacy per-game scaled fallback used when snapshot rows are unavailable."""
 
         train_frame = source[
             source[self.adapter_config.date_col] <= train_cutoff
@@ -447,8 +833,24 @@ class MlbSeasonProjectionAdapter:
         )
         sample_sizes.index = per_game_mean.index
         mean_by_entity = (per_game_mean * sample_sizes).astype("float64")
-        residuals = pd.to_numeric(residuals, errors="coerce").dropna()
-        return mean_by_entity, residuals.astype("float64"), str(model_name)
+        clean_residuals = pd.to_numeric(residuals, errors="coerce").dropna()
+        season_to_date_pa = (
+            pd.to_numeric(
+                infer_history_frame.groupby(entity_id_col)["plate_appearances"].sum(),
+                errors="coerce",
+            )
+            .reindex(mean_by_entity.index)
+            .fillna(0.0)
+        )
+        return CountProjectionDetails(
+            mean_by_entity=mean_by_entity,
+            residuals=clean_residuals.astype("float64"),
+            model_name=str(model_name),
+            bucket_by_entity=self._bucket_labels_from_values(season_to_date_pa),
+            residuals_by_bucket={
+                "default": clean_residuals.astype("float64"),
+            },
+        )
 
     def _resolve_window_for_metric(
         self, config: ContestConfig, metric_id: str
@@ -505,7 +907,20 @@ class MlbSeasonProjectionAdapter:
 
     @staticmethod
     def _feature_set_hash(metric_id: str) -> str:
-        ordered = "|".join(model_feature_columns_for_metric(metric_id))
+        normalized = metric_id.strip().lower()
+        if normalized == "plate_appearances":
+            ordered = "|".join(PA_SNAPSHOT_FEATURES)
+        elif normalized == "hits":
+            ordered = "|".join(HITS_SNAPSHOT_FEATURES)
+        elif normalized == "hit_rate":
+            ordered = (
+                "counts_only|"
+                + "|".join(HITS_SNAPSHOT_FEATURES)
+                + "|"
+                + "|".join(PA_SNAPSHOT_FEATURES)
+            )
+        else:
+            ordered = "|".join(model_feature_columns_for_metric(metric_id))
         digest = hashlib.sha1(ordered.encode("utf-8")).hexdigest()
         return digest[:8]
 
@@ -534,6 +949,7 @@ class MlbSeasonProjectionAdapter:
         train_frame: pd.DataFrame,
         infer_frame: pd.DataFrame,
         target_col: str | None = None,
+        feature_columns: list[str] | None = None,
     ) -> tuple[pd.DataFrame, pd.Series, str]:
         """Fit/predict through existing MLB estimator utilities with safe fallback."""
 
@@ -542,7 +958,9 @@ class MlbSeasonProjectionAdapter:
         if resolved_target_col not in working_infer.columns:
             working_infer[resolved_target_col] = 0.0
 
-        features = model_feature_columns_for_metric(resolved_target_col)
+        features = feature_columns or model_feature_columns_for_metric(
+            resolved_target_col
+        )
 
         if train_frame.empty:
             baseline = float(
@@ -563,7 +981,11 @@ class MlbSeasonProjectionAdapter:
             working_train[resolved_target_col], errors="coerce"
         ).fillna(0.0)
 
-        model_name = self.adapter_config.model_name
+        model_name = self._resolve_model_name_for_training(
+            train_frame=working_train,
+            target_col=resolved_target_col,
+            features=features,
+        )
         try:
             spec = get_model_spec(model_name)
         except KeyError:
@@ -605,6 +1027,180 @@ class MlbSeasonProjectionAdapter:
             working_infer["prediction"] = baseline
             residuals = working_train[resolved_target_col] - baseline
             return working_infer, residuals.astype("float64"), "baseline"
+
+    def _resolve_model_name_for_training(
+        self,
+        *,
+        train_frame: pd.DataFrame,
+        target_col: str,
+        features: list[str],
+    ) -> str:
+        """Resolve model family using deterministic score-based selection."""
+
+        default_model_name = str(self.adapter_config.model_name).strip().lower()
+        if not self.adapter_config.model_selection_enabled:
+            return default_model_name
+
+        candidates = [
+            str(name).strip().lower()
+            for name in self.adapter_config.model_selection_candidates
+            if str(name).strip()
+        ]
+        if default_model_name and default_model_name not in candidates:
+            candidates.insert(0, default_model_name)
+
+        score_rows: list[dict[str, float | str]] = []
+        for candidate in candidates:
+            try:
+                spec = get_model_spec(candidate)
+            except KeyError:
+                continue
+            try:
+                fit_params: dict[str, int] | None = None
+                if self._supports_random_state(spec):
+                    fit_params = {"random_state": self.adapter_config.seed}
+                model = fit_estimator(
+                    train_frame,
+                    spec=spec,
+                    features=features,
+                    target_col=target_col,
+                    params=fit_params,
+                )
+                prediction = predict_estimator(
+                    train_frame,
+                    model=model,
+                    features=features,
+                    name="prediction",
+                )
+                actual = pd.to_numeric(train_frame[target_col], errors="coerce")
+                valid = actual.notna() & pd.to_numeric(
+                    prediction, errors="coerce"
+                ).notna()
+                if not valid.any():
+                    continue
+                err = (
+                    pd.to_numeric(prediction.loc[valid], errors="coerce")
+                    - actual.loc[valid]
+                ).astype("float64")
+                mae = float(err.abs().mean())
+                rmse = float(np.sqrt((err**2).mean()))
+                abs_bias = float(abs(err.mean()))
+                score_rows.append(
+                    {
+                        "model_name": candidate,
+                        "mae": mae,
+                        "rmse": rmse,
+                        "abs_bias": abs_bias,
+                    }
+                )
+            except Exception:
+                continue
+
+        if not score_rows:
+            return default_model_name
+        scores = pd.DataFrame(score_rows)
+        return self._select_model_name_from_scores(
+            scores=scores,
+            default_model_name=default_model_name,
+            min_delta_mae=float(self.adapter_config.selection_min_delta_mae),
+        )
+
+    @staticmethod
+    def _select_model_name_from_scores(
+        *,
+        scores: pd.DataFrame,
+        default_model_name: str,
+        min_delta_mae: float,
+    ) -> str:
+        """Select candidate by MAE, RMSE, then abs-bias with anti-churn threshold."""
+
+        required = {"model_name", "mae", "rmse", "abs_bias"}
+        if scores.empty or not required.issubset(scores.columns):
+            return str(default_model_name).strip().lower()
+
+        ranked = scores.copy()
+        ranked["model_name"] = ranked["model_name"].astype(str).str.strip().str.lower()
+        for column in ("mae", "rmse", "abs_bias"):
+            ranked[column] = pd.to_numeric(ranked[column], errors="coerce")
+        ranked = ranked.dropna(subset=["model_name", "mae", "rmse", "abs_bias"])
+        if ranked.empty:
+            return str(default_model_name).strip().lower()
+
+        ranked = ranked.sort_values(
+            ["mae", "rmse", "abs_bias", "model_name"], kind="stable"
+        ).reset_index(drop=True)
+        best = ranked.iloc[0]
+        winner = str(best["model_name"])
+
+        default = str(default_model_name).strip().lower()
+        if not default:
+            return winner
+        default_rows = ranked[ranked["model_name"] == default]
+        if default_rows.empty:
+            return winner
+        default_mae = float(default_rows.iloc[0]["mae"])
+        best_mae = float(best["mae"])
+        if winner == default:
+            return default
+
+        improvement = default_mae - best_mae
+        if improvement <= max(float(min_delta_mae), 0.0):
+            return default
+        return winner
+
+    def _bucket_labels_from_values(self, values: pd.Series) -> pd.Series:
+        """Build deterministic bucket labels from season-to-date PA values."""
+
+        numeric = pd.to_numeric(values, errors="coerce").fillna(0.0).clip(lower=0.0)
+        raw_edges = [
+            float(edge) for edge in self.adapter_config.uncertainty_bucket_edges
+        ]
+        edges = sorted(set(raw_edges))
+        if not edges:
+            return pd.Series("default", index=numeric.index, dtype="object")
+
+        labels: list[str] = []
+        for idx in range(len(edges) - 1):
+            start = int(edges[idx])
+            end = int(edges[idx + 1])
+            labels.append(f"{start}_{end}")
+        labels.append(f"{int(edges[-1])}_plus")
+
+        bucket_values = pd.cut(
+            numeric,
+            bins=[*edges, float("inf")],
+            labels=labels,
+            right=False,
+            include_lowest=True,
+        )
+        return bucket_values.astype("object").fillna("default")
+
+    def _build_residual_bank_by_bucket(
+        self,
+        *,
+        values: pd.Series,
+        residuals: pd.Series,
+    ) -> dict[str, pd.Series]:
+        """Group residual vectors into configured season-to-date PA buckets."""
+
+        clean_residuals = pd.to_numeric(residuals, errors="coerce").dropna().astype(
+            "float64"
+        )
+        if clean_residuals.empty:
+            return {"default": pd.Series([0.0], dtype="float64")}
+        aligned_values = (
+            pd.to_numeric(values, errors="coerce")
+            .reindex(clean_residuals.index)
+            .fillna(0.0)
+        )
+        buckets = self._bucket_labels_from_values(aligned_values)
+        banks: dict[str, pd.Series] = {"default": clean_residuals}
+        for bucket, idx in buckets.groupby(buckets).groups.items():
+            bank = clean_residuals.loc[list(idx)]
+            if bank.empty:
+                continue
+            banks[str(bucket)] = bank.astype("float64")
+        return banks
 
     @staticmethod
     def _supports_random_state(spec: Any) -> bool:

--- a/src/fantasy/adapters/mlb/projection_adapter.py
+++ b/src/fantasy/adapters/mlb/projection_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 from dataclasses import dataclass
 from typing import Any
@@ -10,8 +11,10 @@ import numpy as np
 import pandas as pd
 
 from src.fantasy.adapters.mlb.features import (
+    is_derived_rate_metric,
     model_feature_columns_for_metric,
     prepare_mlb_projection_frame,
+    rate_metric_inputs,
 )
 from src.fantasy.adapters.mlb.uncertainty import (
     availability_confidence_by_entity,
@@ -42,9 +45,10 @@ NEUTRAL_OUTPUT_COLUMNS: tuple[str, ...] = (
 
 @dataclass(frozen=True, slots=True)
 class MlbProjectionAdapterConfig:
-    """Runtime settings for the Phase 1 MLB projection adapter."""
+    """Runtime settings for the Phase 1.5 MLB projection adapter."""
 
     input_dataset_path: str
+    training_data_paths: tuple[str, ...] = ()
     entity_id_col: str = "batter"
     date_col: str = "game_date"
     seed: int = 2026
@@ -53,35 +57,114 @@ class MlbProjectionAdapterConfig:
     train_end_date: str | None = None
     inference_anchor_date: str | None = None
     uncertainty_method: str = "empirical_quantiles"
+    snapshot_anchor_frequency: str = "weekly"
+    snapshot_min_games: int = 5
+    model_selection_enabled: bool = False
+    model_selection_candidates: tuple[str, ...] = (
+        "poisson",
+        "elastic_net",
+        "hist_gradient_boosting",
+        "xgboost",
+    )
+    model_selection_primary_metric: str = "mae"
+    model_selection_max_trials_per_model: int = 1
+    pybaseball_priors_enabled: bool = False
+    pybaseball_priors_cache_path: str = ""
+    pybaseball_priors_seasons: tuple[int, ...] = ()
+    pybaseball_priors_refresh: bool = False
+    uncertainty_residual_bucket_col: str = "season_to_date_pa"
+    uncertainty_bucket_edges: tuple[float, ...] = (0.0, 100.0, 250.0, 450.0, 700.0)
     source_snapshot_id: str | None = None
 
     @classmethod
     def from_mapping(cls, payload: dict[str, Any]) -> MlbProjectionAdapterConfig:
         """Construct config from a plain mapping payload."""
 
+        phase15 = payload.get("mlb_projection_phase15")
+        if isinstance(phase15, dict):
+            effective = dict(payload)
+            effective.update(phase15)
+        else:
+            effective = dict(payload)
+
+        candidates_raw = effective.get("model_selection_candidates")
+        if isinstance(candidates_raw, list):
+            candidates = tuple(str(value).strip().lower() for value in candidates_raw)
+        else:
+            candidates = (
+                "poisson",
+                "elastic_net",
+                "hist_gradient_boosting",
+                "xgboost",
+            )
+        prior_seasons_raw = effective.get("pybaseball_priors_seasons")
+        if isinstance(prior_seasons_raw, list):
+            prior_seasons = tuple(int(value) for value in prior_seasons_raw)
+        else:
+            prior_seasons = ()
+        edges_raw = effective.get("uncertainty_bucket_edges")
+        if isinstance(edges_raw, list):
+            bucket_edges = tuple(float(value) for value in edges_raw)
+        else:
+            bucket_edges = (0.0, 100.0, 250.0, 450.0, 700.0)
+        training_paths_raw = effective.get("training_data_paths")
+        if isinstance(training_paths_raw, list):
+            training_data_paths = tuple(str(path) for path in training_paths_raw)
+        else:
+            training_data_paths = ()
+
         return cls(
-            input_dataset_path=str(payload["input_dataset_path"]),
-            entity_id_col=str(payload.get("entity_id_col", "batter")),
-            date_col=str(payload.get("date_col", "game_date")),
-            seed=int(payload.get("seed", 2026)),
-            min_history_games=int(payload.get("min_history_games", 20)),
-            model_name=str(payload.get("model_name", "xgboost")),
+            input_dataset_path=str(effective["input_dataset_path"]),
+            training_data_paths=training_data_paths,
+            entity_id_col=str(effective.get("entity_id_col", "batter")),
+            date_col=str(effective.get("date_col", "game_date")),
+            seed=int(effective.get("seed", 2026)),
+            min_history_games=int(effective.get("min_history_games", 20)),
+            model_name=str(effective.get("model_name", "xgboost")),
             train_end_date=(
-                str(payload["train_end_date"])
-                if payload.get("train_end_date") is not None
+                str(effective["train_end_date"])
+                if effective.get("train_end_date") is not None
                 else None
             ),
             inference_anchor_date=(
-                str(payload["inference_anchor_date"])
-                if payload.get("inference_anchor_date") is not None
+                str(effective["inference_anchor_date"])
+                if effective.get("inference_anchor_date") is not None
                 else None
             ),
             uncertainty_method=str(
-                payload.get("uncertainty_method", "empirical_quantiles")
+                effective.get("uncertainty_method", "empirical_quantiles")
             ),
+            snapshot_anchor_frequency=str(
+                effective.get("snapshot_anchor_frequency", "weekly")
+            ),
+            snapshot_min_games=int(effective.get("snapshot_min_games", 5)),
+            model_selection_enabled=bool(
+                effective.get("model_selection_enabled", False)
+            ),
+            model_selection_candidates=candidates,
+            model_selection_primary_metric=str(
+                effective.get("model_selection_primary_metric", "mae")
+            ),
+            model_selection_max_trials_per_model=int(
+                effective.get("model_selection_max_trials_per_model", 1)
+            ),
+            pybaseball_priors_enabled=bool(
+                effective.get("pybaseball_priors_enabled", False)
+            ),
+            pybaseball_priors_cache_path=str(
+                effective.get("pybaseball_priors_cache_path", "")
+            ),
+            pybaseball_priors_seasons=prior_seasons,
+            pybaseball_priors_refresh=bool(
+                effective.get("pybaseball_priors_refresh", False)
+            ),
+            uncertainty_residual_bucket_col=str(
+                effective.get("uncertainty_residual_bucket_col", "season_to_date_pa")
+            ),
+            uncertainty_bucket_edges=bucket_edges,
             source_snapshot_id=(
-                str(payload["source_snapshot_id"])
-                if payload.get("source_snapshot_id") is not None
+                str(effective["source_snapshot_id"])
+                if effective.get("source_snapshot_id") is not None
                 else None
             ),
         )
@@ -112,7 +195,123 @@ class MlbSeasonProjectionAdapter:
         )
 
         window_start, window_end = self._resolve_window(config)
-        window_end_effective = window_end
+        context = self._build_projection_context(
+            source, window_start=window_start, window_end=window_end
+        )
+        confidence_frame = context["confidence_frame"]
+        sample_sizes = context["sample_sizes"]
+
+        if is_derived_rate_metric(self.metric_id):
+            numerator, denominator = rate_metric_inputs(self.metric_id)
+            numerator_mean = self._predict_count_mean_by_entity(
+                metric_id=numerator,
+                config=config,
+                source=source,
+            )
+            denominator_mean = self._predict_count_mean_by_entity(
+                metric_id=denominator,
+                config=config,
+                source=source,
+            ).clip(lower=0.0)
+            _, numerator_residuals, numerator_model_name = (
+                self._predict_count_projection_details(
+                    metric_id=numerator,
+                    config=config,
+                    source=source,
+                )
+            )
+            _, denominator_residuals, denominator_model_name = (
+                self._predict_count_projection_details(
+                    metric_id=denominator,
+                    config=config,
+                    source=source,
+                )
+            )
+            entity_index = numerator_mean.index.union(denominator_mean.index)
+            numerator_mean = numerator_mean.reindex(entity_index).fillna(0.0)
+            denominator_mean = denominator_mean.reindex(entity_index).fillna(0.0)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                values = np.where(
+                    denominator_mean.to_numpy(dtype="float64") > 0.0,
+                    numerator_mean.to_numpy(dtype="float64")
+                    / denominator_mean.to_numpy(dtype="float64"),
+                    0.0,
+                )
+            mean_by_entity = pd.Series(values, index=entity_index, dtype="float64")
+            model_name = numerator_model_name
+            if denominator_model_name != numerator_model_name:
+                model_name = f"{numerator_model_name}+{denominator_model_name}"
+            residuals = numerator_residuals
+            if residuals.empty:
+                residuals = denominator_residuals
+            sample_sizes = (
+                sample_sizes.reindex(entity_index).fillna(1.0).clip(lower=1.0)
+            )
+        else:
+            mean_by_entity, residuals, model_name = (
+                self._predict_count_projection_details(
+                    metric_id=self.metric_id,
+                    config=config,
+                    source=source,
+                )
+            )
+            sample_sizes = (
+                sample_sizes.reindex(mean_by_entity.index).fillna(1.0).clip(lower=1.0)
+            )
+
+        uncertainty = summarize_empirical_uncertainty(
+            mean_by_entity=mean_by_entity,
+            sample_size_by_entity=sample_sizes,
+            residuals=residuals,
+        )
+        entity_id_col = self.adapter_config.entity_id_col
+        availability = availability_confidence_by_entity(
+            confidence_frame,
+            entity_id_col=entity_id_col,
+            date_col=self.adapter_config.date_col,
+            min_history_games=self.adapter_config.min_history_games,
+        )
+
+        window_end_effective = context["window_end_effective"]
+        snapshot_id = (
+            self.adapter_config.source_snapshot_id
+            or str(config.metadata.get("source_snapshot_id", ""))
+            or window_end_effective.date().isoformat()
+        )
+
+        source_model_version = (
+            f"{model_name}_phase15_{self._feature_set_hash(self.metric_id)}"
+        )
+        output = pd.DataFrame(
+            {
+                "entity_id": mean_by_entity.index.astype(str),
+                "sport": "mlb",
+                "metric_id": self.metric_id,
+                "horizon": "season",
+                "window_start": window_start.date().isoformat(),
+                "window_end": window_end.date().isoformat(),
+                "game_id": None,
+                "mean": mean_by_entity.values,
+                "availability_confidence": availability.reindex(mean_by_entity.index)
+                .fillna(0.0)
+                .values,
+                "source_model_version": source_model_version,
+                "source_snapshot_id": snapshot_id,
+            }
+        )
+        output = output.join(uncertainty, on="entity_id")
+        output = output.sort_values(["entity_id"], kind="stable").reset_index(drop=True)
+
+        return output.loc[:, list(NEUTRAL_OUTPUT_COLUMNS)]
+
+    def _build_projection_context(
+        self,
+        source: pd.DataFrame,
+        *,
+        window_start: pd.Timestamp,
+        window_end: pd.Timestamp,
+    ) -> dict[str, Any]:
+        window_end_effective = pd.Timestamp(window_end)
         if self.adapter_config.inference_anchor_date is not None:
             anchor = pd.to_datetime(
                 self.adapter_config.inference_anchor_date, errors="coerce"
@@ -128,12 +327,72 @@ class MlbSeasonProjectionAdapter:
             if not pd.isna(anchor):
                 feature_cutoff = min(feature_cutoff, pd.Timestamp(anchor))
 
+        infer_history_frame = source[
+            source[self.adapter_config.date_col] <= feature_cutoff
+        ].copy()
+        if infer_history_frame.empty:
+            confidence_frame = source.groupby(
+                self.adapter_config.entity_id_col, as_index=False
+            ).head(1)
+            confidence_frame = confidence_frame.copy()
+            confidence_frame[self.adapter_config.date_col] = feature_cutoff
+        else:
+            confidence_frame = infer_history_frame.copy()
+
+        horizon_days = max((window_end - window_start).days + 1, 1)
+        expected_games = self._expected_games_by_entity(
+            infer_history_frame=infer_history_frame,
+            fallback_frame=confidence_frame,
+            horizon_days=horizon_days,
+        )
+        return {
+            "window_end_effective": window_end_effective,
+            "feature_cutoff": feature_cutoff,
+            "confidence_frame": confidence_frame,
+            "sample_sizes": expected_games.clip(lower=1.0).astype("float64"),
+        }
+
+    def _predict_count_mean_by_entity(
+        self,
+        *,
+        metric_id: str,
+        config: ContestConfig,
+        source: pd.DataFrame,
+    ) -> pd.Series:
+        """Predict season-horizon totals for a count-like metric."""
+
+        mean_by_entity, _residuals, _model_name = (
+            self._predict_count_projection_details(
+                metric_id=metric_id,
+                config=config,
+                source=source,
+            )
+        )
+        return mean_by_entity
+
+    def _predict_count_projection_details(
+        self,
+        *,
+        metric_id: str,
+        config: ContestConfig,
+        source: pd.DataFrame,
+    ) -> tuple[pd.Series, pd.Series, str]:
+        """Predict count totals with residuals and resolved model provenance."""
+
+        window_start, window_end = self._resolve_window_for_metric(config, metric_id)
+        context = self._build_projection_context(
+            source,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        feature_cutoff = context["feature_cutoff"]
+
         train_cutoff = pd.to_datetime(
             self.adapter_config.train_end_date, errors="coerce"
         )
         if pd.isna(train_cutoff):
             train_cutoff = feature_cutoff
-        train_cutoff = min(pd.Timestamp(train_cutoff), feature_cutoff)
+        train_cutoff = min(pd.Timestamp(train_cutoff), pd.Timestamp(feature_cutoff))
 
         train_frame = source[
             source[self.adapter_config.date_col] <= train_cutoff
@@ -156,119 +415,99 @@ class MlbSeasonProjectionAdapter:
                 if column in keep_cols:
                     continue
                 infer_frame[column] = 0.0
-            confidence_frame = infer_frame
         else:
-            confidence_frame = infer_history_frame
             infer_frame = infer_history_frame.groupby(
                 self.adapter_config.entity_id_col, as_index=False
             ).tail(1)
-
-        horizon_days = max((window_end - window_start).days + 1, 1)
-        if infer_history_frame.empty:
-            expected_games_by_entity = pd.Series(
-                1.0,
-                index=infer_frame[self.adapter_config.entity_id_col]
-                .astype(str)
-                .drop_duplicates(),
-                dtype="float64",
-            )
-        else:
-            history_span = infer_history_frame[
-                [self.adapter_config.entity_id_col, self.adapter_config.date_col]
-            ].copy()
-            history_span[self.adapter_config.date_col] = pd.to_datetime(
-                history_span[self.adapter_config.date_col], errors="coerce"
-            )
-            history_span = history_span.dropna(subset=[self.adapter_config.date_col])
-
-            if history_span.empty:
-                expected_games_by_entity = pd.Series(
-                    1.0,
-                    index=infer_frame[self.adapter_config.entity_id_col]
-                    .astype(str)
-                    .drop_duplicates(),
-                    dtype="float64",
-                )
-            else:
-                span_stats = history_span.groupby(
-                    self.adapter_config.entity_id_col, dropna=False
-                )[self.adapter_config.date_col].agg(["min", "max", "size"])
-                observed_days = (
-                    (span_stats["max"] - span_stats["min"])
-                    .dt.days.add(1)
-                    .clip(lower=1)
-                    .astype("float64")
-                )
-                games_per_day = span_stats["size"].astype("float64") / observed_days
-                expected_games_by_entity = (games_per_day * float(horizon_days)).clip(
-                    lower=1.0
-                )
-                expected_games_by_entity.index = (
-                    expected_games_by_entity.index.astype(str)
-                )
 
         infer_frame = infer_frame.sort_values(
             [self.adapter_config.entity_id_col, self.adapter_config.date_col],
             kind="stable",
         )
-
-        infer_frame, residuals, model_name = self._apply_model(
-            train_frame=train_frame,
-            infer_frame=infer_frame,
-        )
+        try:
+            infer_frame, residuals, model_name = self._apply_model(
+                train_frame=train_frame,
+                infer_frame=infer_frame,
+                target_col=metric_id,
+            )
+        except TypeError:
+            if metric_id != self.metric_id:
+                raise
+            infer_frame, residuals, model_name = self._apply_model(
+                train_frame=train_frame,
+                infer_frame=infer_frame,
+            )
 
         entity_id_col = self.adapter_config.entity_id_col
         per_game_mean = (
             infer_frame.groupby(entity_id_col)["prediction"].mean().astype("float64")
         )
-        expected_games = expected_games_by_entity.reindex(
-            per_game_mean.index.astype(str)
-        ).fillna(1.0)
-        expected_games.index = per_game_mean.index
         sample_sizes = (
-            expected_games.astype("float64").clip(lower=1.0)
+            context["sample_sizes"].reindex(per_game_mean.index.astype(str)).fillna(1.0)
         )
-        mean_by_entity = (per_game_mean * expected_games).astype("float64")
+        sample_sizes.index = per_game_mean.index
+        mean_by_entity = (per_game_mean * sample_sizes).astype("float64")
+        residuals = pd.to_numeric(residuals, errors="coerce").dropna()
+        return mean_by_entity, residuals.astype("float64"), str(model_name)
 
-        uncertainty = summarize_empirical_uncertainty(
-            mean_by_entity=mean_by_entity,
-            sample_size_by_entity=sample_sizes,
-            residuals=residuals,
-        )
-        availability = availability_confidence_by_entity(
-            confidence_frame,
-            entity_id_col=entity_id_col,
-            date_col=self.adapter_config.date_col,
-            min_history_games=self.adapter_config.min_history_games,
-        )
+    def _resolve_window_for_metric(
+        self, config: ContestConfig, metric_id: str
+    ) -> tuple[pd.Timestamp, pd.Timestamp]:
+        for market in config.market_definitions:
+            if (
+                market.metric_id.strip().lower() == metric_id.strip().lower()
+                and market.horizon.strip().lower() == "season"
+            ):
+                start = pd.to_datetime(market.window_start, errors="coerce")
+                end = pd.to_datetime(market.window_end, errors="coerce")
+                if not pd.isna(start) and not pd.isna(end):
+                    return pd.Timestamp(start), pd.Timestamp(end)
+        return self._resolve_window(config)
 
-        snapshot_id = (
-            self.adapter_config.source_snapshot_id
-            or str(config.metadata.get("source_snapshot_id", ""))
-            or window_end_effective.date().isoformat()
-        )
+    def _expected_games_by_entity(
+        self,
+        *,
+        infer_history_frame: pd.DataFrame,
+        fallback_frame: pd.DataFrame,
+        horizon_days: int,
+    ) -> pd.Series:
+        entity_id_col = self.adapter_config.entity_id_col
+        date_col = self.adapter_config.date_col
+        if infer_history_frame.empty:
+            return pd.Series(
+                1.0,
+                index=fallback_frame[entity_id_col].astype(str).drop_duplicates(),
+                dtype="float64",
+            )
 
-        output = pd.DataFrame(
-            {
-                "entity_id": mean_by_entity.index.astype(str),
-                "sport": "mlb",
-                "metric_id": self.metric_id,
-                "horizon": "season",
-                "window_start": window_start.date().isoformat(),
-                "window_end": window_end.date().isoformat(),
-                "game_id": None,
-                "mean": mean_by_entity.values,
-                "availability_confidence": availability.reindex(mean_by_entity.index)
-                .fillna(0.0)
-                .values,
-                "source_model_version": f"{model_name}_phase1",
-                "source_snapshot_id": snapshot_id,
-            }
+        history_span = infer_history_frame[[entity_id_col, date_col]].copy()
+        history_span[date_col] = pd.to_datetime(history_span[date_col], errors="coerce")
+        history_span = history_span.dropna(subset=[date_col])
+        if history_span.empty:
+            return pd.Series(
+                1.0,
+                index=fallback_frame[entity_id_col].astype(str).drop_duplicates(),
+                dtype="float64",
+            )
+        span_stats = history_span.groupby(entity_id_col, dropna=False)[date_col].agg(
+            ["min", "max", "size"]
         )
-        output = output.join(uncertainty, on="entity_id")
-        output = output.sort_values(["entity_id"], kind="stable").reset_index(drop=True)
+        observed_days = (
+            (span_stats["max"] - span_stats["min"])
+            .dt.days.add(1)
+            .clip(lower=1)
+            .astype("float64")
+        )
+        games_per_day = span_stats["size"].astype("float64") / observed_days
+        expected_games_by_entity = (games_per_day * float(horizon_days)).clip(lower=1.0)
+        expected_games_by_entity.index = expected_games_by_entity.index.astype(str)
+        return expected_games_by_entity
 
-        return output.loc[:, list(NEUTRAL_OUTPUT_COLUMNS)]
+    @staticmethod
+    def _feature_set_hash(metric_id: str) -> str:
+        ordered = "|".join(model_feature_columns_for_metric(metric_id))
+        digest = hashlib.sha1(ordered.encode("utf-8")).hexdigest()
+        return digest[:8]
 
     def _resolve_window(
         self, config: ContestConfig
@@ -294,19 +533,22 @@ class MlbSeasonProjectionAdapter:
         *,
         train_frame: pd.DataFrame,
         infer_frame: pd.DataFrame,
+        target_col: str | None = None,
     ) -> tuple[pd.DataFrame, pd.Series, str]:
         """Fit/predict through existing MLB estimator utilities with safe fallback."""
 
         working_infer = infer_frame.copy()
-        target_col = self.metric_id
-        if target_col not in working_infer.columns:
-            working_infer[target_col] = 0.0
+        resolved_target_col = target_col or self.metric_id
+        if resolved_target_col not in working_infer.columns:
+            working_infer[resolved_target_col] = 0.0
 
-        features = model_feature_columns_for_metric(target_col)
+        features = model_feature_columns_for_metric(resolved_target_col)
 
         if train_frame.empty:
             baseline = float(
-                pd.to_numeric(working_infer[target_col], errors="coerce").mean()
+                pd.to_numeric(
+                    working_infer[resolved_target_col], errors="coerce"
+                ).mean()
             )
             if np.isnan(baseline):
                 baseline = 0.0
@@ -315,10 +557,10 @@ class MlbSeasonProjectionAdapter:
             return working_infer, residuals, "baseline"
 
         working_train = train_frame.copy()
-        if target_col not in working_train.columns:
-            working_train[target_col] = 0.0
-        working_train[target_col] = pd.to_numeric(
-            working_train[target_col], errors="coerce"
+        if resolved_target_col not in working_train.columns:
+            working_train[resolved_target_col] = 0.0
+        working_train[resolved_target_col] = pd.to_numeric(
+            working_train[resolved_target_col], errors="coerce"
         ).fillna(0.0)
 
         model_name = self.adapter_config.model_name
@@ -336,7 +578,7 @@ class MlbSeasonProjectionAdapter:
                 working_train,
                 spec=spec,
                 features=features,
-                target_col=target_col,
+                target_col=resolved_target_col,
                 params=fit_params,
             )
             train_pred = predict_estimator(
@@ -352,16 +594,16 @@ class MlbSeasonProjectionAdapter:
                 name="prediction",
             )
             working_infer["prediction"] = infer_pred.astype("float64")
-            residuals = working_train[target_col].astype("float64") - train_pred.astype(
+            residuals = working_train[resolved_target_col].astype(
                 "float64"
-            )
+            ) - train_pred.astype("float64")
             return working_infer, residuals, model_name
         except Exception:
-            baseline = float(working_train[target_col].mean())
+            baseline = float(working_train[resolved_target_col].mean())
             if np.isnan(baseline):
                 baseline = 0.0
             working_infer["prediction"] = baseline
-            residuals = working_train[target_col] - baseline
+            residuals = working_train[resolved_target_col] - baseline
             return working_infer, residuals.astype("float64"), "baseline"
 
     @staticmethod

--- a/src/fantasy/adapters/mlb/uncertainty.py
+++ b/src/fantasy/adapters/mlb/uncertainty.py
@@ -103,6 +103,118 @@ def summarize_bucketed_uncertainty(
     return output.reindex(mean_by_entity.index)
 
 
+def summarize_hit_rate_uncertainty_from_counts(
+    *,
+    hit_mean_by_entity: pd.Series,
+    pa_mean_by_entity: pd.Series,
+    sample_size_by_entity: pd.Series,
+    hit_residuals: pd.Series,
+    pa_residuals: pd.Series,
+    seed: int,
+    draws: int = 500,
+    residual_scale_global: float = 1.0,
+    residual_scale_by_bucket: dict[str, float] | None = None,
+    bucket_by_entity: pd.Series | None = None,
+    hit_residuals_by_bucket: dict[str, pd.Series] | None = None,
+    pa_residuals_by_bucket: dict[str, pd.Series] | None = None,
+    min_bucket_residual_count: int = 100,
+) -> pd.DataFrame:
+    """Build bounded hit-rate intervals from count residual simulation."""
+
+    entity_index = hit_mean_by_entity.index.union(pa_mean_by_entity.index)
+    if entity_index.empty:
+        return pd.DataFrame(columns=["p10", "p50", "p90", "stddev"])
+
+    hit_mean = hit_mean_by_entity.reindex(entity_index).fillna(0.0).astype("float64")
+    pa_mean = pa_mean_by_entity.reindex(entity_index).fillna(0.0).astype("float64")
+    sample_sizes = (
+        pd.to_numeric(sample_size_by_entity, errors="coerce")
+        .reindex(entity_index)
+        .fillna(1.0)
+        .clip(lower=1.0)
+    )
+    hit_res = pd.to_numeric(hit_residuals, errors="coerce").dropna().astype("float64")
+    pa_res = pd.to_numeric(pa_residuals, errors="coerce").dropna().astype("float64")
+    if hit_res.empty:
+        hit_res = pd.Series([0.0], dtype="float64")
+    if pa_res.empty:
+        pa_res = pd.Series([0.0], dtype="float64")
+
+    residual_scale = max(float(residual_scale_global), 0.0)
+    bucket_scales = {
+        str(bucket): max(float(scale), 0.0)
+        for bucket, scale in (residual_scale_by_bucket or {}).items()
+    }
+    entity_buckets = pd.Series("default", index=entity_index, dtype="object")
+    if bucket_by_entity is not None and not bucket_by_entity.empty:
+        bucket_values = bucket_by_entity.reindex(entity_index).fillna("default")
+        entity_buckets = bucket_values.astype(str)
+
+    hit_bucket_map: dict[str, pd.Series] = {}
+    for bucket, series in (hit_residuals_by_bucket or {}).items():
+        cleaned = pd.to_numeric(series, errors="coerce").dropna().astype("float64")
+        if int(cleaned.shape[0]) >= int(max(min_bucket_residual_count, 1)):
+            hit_bucket_map[str(bucket)] = cleaned
+    pa_bucket_map: dict[str, pd.Series] = {}
+    for bucket, series in (pa_residuals_by_bucket or {}).items():
+        cleaned = pd.to_numeric(series, errors="coerce").dropna().astype("float64")
+        if int(cleaned.shape[0]) >= int(max(min_bucket_residual_count, 1)):
+            pa_bucket_map[str(bucket)] = cleaned
+
+    hit_default_values = hit_res.to_numpy(dtype="float64")
+    pa_default_values = pa_res.to_numpy(dtype="float64")
+
+    rng = np.random.default_rng(seed)
+    simulations = np.zeros((len(entity_index), int(max(draws, 1))), dtype="float64")
+    for idx, entity_id in enumerate(entity_index):
+        bucket = str(entity_buckets.loc[entity_id])
+        bucket_scale = bucket_scales.get(bucket, 1.0)
+        scale_multiplier = residual_scale * bucket_scale
+        hit_res_values = hit_bucket_map.get(bucket, hit_res).to_numpy(dtype="float64")
+        pa_res_values = pa_bucket_map.get(bucket, pa_res).to_numpy(dtype="float64")
+        if hit_res_values.size == 0:
+            hit_res_values = hit_default_values
+        if pa_res_values.size == 0:
+            pa_res_values = pa_default_values
+        scale = math.sqrt(float(sample_sizes.loc[entity_id]))
+        sampled_hit = rng.choice(
+            hit_res_values, size=simulations.shape[1], replace=True
+        )
+        sampled_pa = rng.choice(pa_res_values, size=simulations.shape[1], replace=True)
+        draw_hits = np.maximum(
+            hit_mean.loc[entity_id] + (sampled_hit * scale * scale_multiplier), 0.0
+        )
+        draw_pa = np.maximum(
+            pa_mean.loc[entity_id] + (sampled_pa * scale * scale_multiplier), 0.0
+        )
+        draw_hits = np.minimum(draw_hits, draw_pa)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            draw_rates = np.where(draw_pa > 0.0, draw_hits / draw_pa, 0.0)
+        simulations[idx, :] = np.clip(draw_rates, 0.0, 1.0)
+
+    p10 = np.quantile(simulations, 0.10, axis=1)
+    p50 = np.quantile(simulations, 0.50, axis=1)
+    p90 = np.quantile(simulations, 0.90, axis=1)
+    stddev = np.std(simulations, axis=1, ddof=1 if simulations.shape[1] > 1 else 0)
+
+    output = pd.DataFrame(
+        {
+            "p10": p10,
+            "p50": p50,
+            "p90": p90,
+            "stddev": stddev,
+        },
+        index=entity_index,
+    )
+    output["p10"] = output["p10"].clip(lower=0.0, upper=1.0)
+    output["p50"] = output["p50"].clip(lower=0.0, upper=1.0)
+    output["p90"] = output["p90"].clip(lower=0.0, upper=1.0)
+    output["p50"] = output[["p10", "p50"]].max(axis=1)
+    output["p90"] = output[["p50", "p90"]].max(axis=1)
+    output["stddev"] = output["stddev"].clip(lower=0.0)
+    return output
+
+
 def availability_confidence_by_entity(
     frame: pd.DataFrame,
     *,

--- a/src/fantasy/adapters/mlb/uncertainty.py
+++ b/src/fantasy/adapters/mlb/uncertainty.py
@@ -65,6 +65,44 @@ def summarize_empirical_uncertainty(
     )
 
 
+def summarize_bucketed_uncertainty(
+    *,
+    mean_by_entity: pd.Series,
+    sample_size_by_entity: pd.Series,
+    residuals_by_bucket: dict[str, pd.Series],
+    bucket_by_entity: pd.Series,
+) -> pd.DataFrame:
+    """Build uncertainty using per-bucket residual distributions."""
+
+    by_entity_rows: dict[str, dict[str, float]] = {}
+    for entity_id, mean_value in mean_by_entity.items():
+        bucket = str(bucket_by_entity.get(entity_id, "default"))
+        residuals = residuals_by_bucket.get(bucket)
+        if residuals is None:
+            residuals = residuals_by_bucket.get("default", pd.Series(dtype="float64"))
+        local = summarize_empirical_uncertainty(
+            mean_by_entity=pd.Series([mean_value], index=[entity_id], dtype="float64"),
+            sample_size_by_entity=pd.Series(
+                [sample_size_by_entity.get(entity_id, 1.0)],
+                index=[entity_id],
+                dtype="float64",
+            ),
+            residuals=residuals,
+        )
+        by_entity_rows[str(entity_id)] = {
+            "p10": float(local.loc[entity_id, "p10"]),
+            "p50": float(local.loc[entity_id, "p50"]),
+            "p90": float(local.loc[entity_id, "p90"]),
+            "stddev": float(local.loc[entity_id, "stddev"]),
+        }
+
+    if not by_entity_rows:
+        return pd.DataFrame(columns=["p10", "p50", "p90", "stddev"])
+    output = pd.DataFrame.from_dict(by_entity_rows, orient="index")
+    output.index.name = mean_by_entity.index.name
+    return output.reindex(mean_by_entity.index)
+
+
 def availability_confidence_by_entity(
     frame: pd.DataFrame,
     *,

--- a/tests/fantasy/adapters/test_mlb_projection_adapter.py
+++ b/tests/fantasy/adapters/test_mlb_projection_adapter.py
@@ -319,6 +319,65 @@ def test_output_window_end_matches_contest_window_when_anchor_is_earlier() -> No
     assert set(projected["window_end"]) == {"2026-06-01"}
 
 
+def test_phase15b_config_controls_parse_from_nested_sections() -> None:
+    from src.fantasy.adapters.mlb.projection_adapter import MlbProjectionAdapterConfig
+
+    config = MlbProjectionAdapterConfig.from_mapping(
+        {
+            "mlb_projection_phase15": {
+                "input_dataset_path": (
+                    "tests/testdata/fantasy/mlb_batter_games_phase1.csv"
+                ),
+                "model_name": "poisson",
+                "modeling": {
+                    "selection_min_delta_mae": 0.02,
+                },
+                "uncertainty": {
+                    "hit_rate_residual_scale_global": 0.75,
+                    "hit_rate_residual_scale_by_bucket": {
+                        "0_100": 0.6,
+                        "100_250": 0.8,
+                    },
+                    "coverage_target": 0.82,
+                    "calibration_objective": "coverage_width_tradeoff",
+                    "min_bucket_residual_count": 25,
+                },
+            }
+        }
+    )
+
+    assert config.selection_min_delta_mae == 0.02
+    assert config.hit_rate_residual_scale_global == 0.75
+    assert config.hit_rate_residual_scale_by_bucket == {"0_100": 0.6, "100_250": 0.8}
+    assert config.coverage_target == 0.82
+    assert config.calibration_objective == "coverage_width_tradeoff"
+    assert config.min_bucket_residual_count == 25
+
+
+def test_model_selection_threshold_keeps_default_for_small_mae_gain() -> None:
+    from src.fantasy.adapters.mlb.projection_adapter import MlbSeasonProjectionAdapter
+
+    scores = pd.DataFrame(
+        [
+            {"model_name": "poisson", "mae": 1.00, "rmse": 1.20, "abs_bias": 0.10},
+            {
+                "model_name": "hist_gradient_boosting",
+                "mae": 0.995,
+                "rmse": 1.18,
+                "abs_bias": 0.08,
+            },
+        ]
+    )
+
+    selected = MlbSeasonProjectionAdapter._select_model_name_from_scores(
+        scores=scores,
+        default_model_name="poisson",
+        min_delta_mae=0.01,
+    )
+
+    assert selected == "poisson"
+
+
 def test_inference_frame_uses_latest_pre_window_row_per_entity(monkeypatch) -> None:
     from src.fantasy.adapters.mlb.projection_adapter import (
         MlbProjectionAdapterConfig,
@@ -598,3 +657,46 @@ def test_phase15_source_model_version_uses_actual_fallback_model(monkeypatch) ->
     projected = adapter.project(_contest("hits", window_end="2026-06-01"))
 
     assert projected["source_model_version"].str.startswith("baseline_phase15_").all()
+
+
+def test_phase15_hit_rate_is_constrained_to_unit_interval(monkeypatch) -> None:
+    from src.fantasy.adapters.mlb.projection_adapter import (
+        MlbProjectionAdapterConfig,
+        MlbSeasonProjectionAdapter,
+    )
+
+    def _fake_projection_details(self, *, metric_id, config, source):
+        if metric_id == "plate_appearances":
+            means = pd.Series({"101": -10.0, "202": 2.0}, dtype="float64")
+            return means, pd.Series([0.0], dtype="float64"), "baseline"
+        if metric_id == "hits":
+            means = pd.Series({"101": 50.0, "202": 3.0}, dtype="float64")
+            return means, pd.Series([0.0], dtype="float64"), "baseline"
+        raise AssertionError(metric_id)
+
+    adapter = MlbSeasonProjectionAdapter(
+        metric_id="hit_rate",
+        adapter_config=MlbProjectionAdapterConfig(
+            input_dataset_path="tests/testdata/fantasy/mlb_batter_games_phase1.csv",
+            entity_id_col="batter",
+            date_col="game_date",
+            seed=2026,
+            min_history_games=2,
+            model_name="xgboost",
+            train_end_date=None,
+            inference_anchor_date="2026-04-01",
+            uncertainty_method="empirical_quantiles",
+            source_snapshot_id="fixture-snapshot",
+        ),
+    )
+    monkeypatch.setattr(
+        MlbSeasonProjectionAdapter,
+        "_predict_count_projection_details",
+        _fake_projection_details,
+    )
+
+    projected = adapter.project(_contest("hit_rate", window_end="2026-06-01"))
+
+    assert ((projected["mean"] >= 0.0) & (projected["mean"] <= 1.0)).all()
+    assert ((projected["p10"] >= 0.0) & (projected["p10"] <= 1.0)).all()
+    assert ((projected["p90"] >= 0.0) & (projected["p90"] <= 1.0)).all()

--- a/tests/fantasy/adapters/test_mlb_projection_adapter.py
+++ b/tests/fantasy/adapters/test_mlb_projection_adapter.py
@@ -489,3 +489,112 @@ def test_poisson_model_name_is_preserved_without_random_state_fallback() -> None
     )
 
     assert model_name == "poisson"
+
+
+def test_phase15_rate_metric_is_derived_from_count_predictions(monkeypatch) -> None:
+    from src.fantasy.adapters.mlb.projection_adapter import (
+        MlbProjectionAdapterConfig,
+        MlbSeasonProjectionAdapter,
+    )
+
+    def _fake_predict_count(self, *, metric_id, config, source):
+        if metric_id == "plate_appearances":
+            return pd.Series({"101": 100.0, "202": 40.0}, dtype="float64")
+        if metric_id == "hits":
+            return pd.Series({"101": 30.0, "202": 10.0}, dtype="float64")
+        raise AssertionError(metric_id)
+
+    adapter = MlbSeasonProjectionAdapter(
+        metric_id="hit_rate",
+        adapter_config=MlbProjectionAdapterConfig(
+            input_dataset_path="tests/testdata/fantasy/mlb_batter_games_phase1.csv",
+            entity_id_col="batter",
+            date_col="game_date",
+            seed=2026,
+            min_history_games=2,
+            model_name="poisson",
+            train_end_date="2025-12-31",
+            inference_anchor_date="2026-04-01",
+            uncertainty_method="empirical_quantiles",
+            source_snapshot_id="fixture-snapshot",
+        ),
+    )
+    monkeypatch.setattr(
+        MlbSeasonProjectionAdapter,
+        "_predict_count_mean_by_entity",
+        _fake_predict_count,
+    )
+
+    projected = adapter.project(_contest("hit_rate", window_end="2026-06-01"))
+
+    rates = projected.set_index("entity_id")["mean"].astype("float64")
+    assert float(rates.loc["101"]) == 0.3
+    assert float(rates.loc["202"]) == 0.25
+
+
+def test_phase15_uncertainty_uses_model_residuals(monkeypatch) -> None:
+    from src.fantasy.adapters.mlb.projection_adapter import (
+        MlbProjectionAdapterConfig,
+        MlbSeasonProjectionAdapter,
+    )
+
+    def _fake_apply_model(self, *, train_frame, infer_frame):
+        predicted = infer_frame.copy()
+        predicted["prediction"] = 2.0
+        residuals = pd.Series([-2.0, 0.0, 2.0], dtype="float64")
+        return predicted, residuals, "poisson"
+
+    adapter = MlbSeasonProjectionAdapter(
+        metric_id="hits",
+        adapter_config=MlbProjectionAdapterConfig(
+            input_dataset_path="tests/testdata/fantasy/mlb_batter_games_phase1.csv",
+            entity_id_col="batter",
+            date_col="game_date",
+            seed=2026,
+            min_history_games=2,
+            model_name="poisson",
+            train_end_date=None,
+            inference_anchor_date="2026-04-01",
+            uncertainty_method="empirical_quantiles",
+            source_snapshot_id="fixture-snapshot",
+        ),
+    )
+    monkeypatch.setattr(MlbSeasonProjectionAdapter, "_apply_model", _fake_apply_model)
+
+    projected = adapter.project(_contest("hits", window_end="2026-06-01"))
+
+    assert (projected["stddev"] > 0.0).all()
+    assert (projected["p10"] < projected["p90"]).all()
+
+
+def test_phase15_source_model_version_uses_actual_fallback_model(monkeypatch) -> None:
+    from src.fantasy.adapters.mlb.projection_adapter import (
+        MlbProjectionAdapterConfig,
+        MlbSeasonProjectionAdapter,
+    )
+
+    def _fake_apply_model(self, *, train_frame, infer_frame):
+        predicted = infer_frame.copy()
+        predicted["prediction"] = 1.0
+        return predicted, pd.Series(dtype="float64"), "baseline"
+
+    adapter = MlbSeasonProjectionAdapter(
+        metric_id="hits",
+        adapter_config=MlbProjectionAdapterConfig(
+            input_dataset_path="tests/testdata/fantasy/mlb_batter_games_phase1.csv",
+            entity_id_col="batter",
+            date_col="game_date",
+            seed=2026,
+            min_history_games=2,
+            model_name="xgboost",
+            train_end_date=None,
+            inference_anchor_date="2026-04-01",
+            uncertainty_method="empirical_quantiles",
+            source_snapshot_id="fixture-snapshot",
+        ),
+    )
+    monkeypatch.setattr(MlbSeasonProjectionAdapter, "_apply_model", _fake_apply_model)
+
+    projected = adapter.project(_contest("hits", window_end="2026-06-01"))
+
+    assert projected["source_model_version"].str.startswith("baseline_phase15_").all()

--- a/tests/fantasy/adapters/test_mlb_projection_phase15_backtest.py
+++ b/tests/fantasy/adapters/test_mlb_projection_phase15_backtest.py
@@ -1,0 +1,60 @@
+"""Phase 1.5 walk-forward backtest tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def test_walk_forward_folds_train_through_prior_season() -> None:
+    from src.fantasy.adapters.mlb.backtest import generate_walk_forward_folds
+
+    folds = generate_walk_forward_folds((2021, 2022, 2023))
+
+    assert len(folds) == 2
+    assert folds[0].train_seasons == (2021,)
+    assert folds[0].test_season == 2022
+    assert folds[1].train_seasons == (2021, 2022)
+    assert folds[1].test_season == 2023
+
+
+def test_backtest_metric_aggregation_computes_mae_rmse_and_bias() -> None:
+    from src.fantasy.adapters.mlb.backtest import aggregate_metric_scores
+
+    frame = pd.DataFrame(
+        {
+            "metric_id": ["hits", "hits", "walks", "walks"],
+            "prediction": [10.0, 8.0, 5.0, 4.0],
+            "actual": [12.0, 7.0, 5.0, 7.0],
+        }
+    )
+
+    scores = aggregate_metric_scores(frame)
+
+    hits = scores[scores["metric_id"] == "hits"].iloc[0]
+    assert float(hits["mae"]) == 1.5
+    assert float(hits["bias"]) == -0.5
+    assert float(hits["rmse"]) > 0.0
+
+
+def test_bucketed_uncertainty_keeps_quantiles_ordered() -> None:
+    from src.fantasy.adapters.mlb.uncertainty import summarize_bucketed_uncertainty
+
+    mean = pd.Series({"101": 10.0, "202": 12.0}, dtype="float64")
+    sample_size = pd.Series({"101": 30.0, "202": 40.0}, dtype="float64")
+    buckets = pd.Series({"101": "low", "202": "high"})
+    residuals = {
+        "low": pd.Series([-1.0, 0.0, 1.0], dtype="float64"),
+        "high": pd.Series([-3.0, 0.0, 2.0], dtype="float64"),
+        "default": pd.Series([0.0], dtype="float64"),
+    }
+
+    summary = summarize_bucketed_uncertainty(
+        mean_by_entity=mean,
+        sample_size_by_entity=sample_size,
+        residuals_by_bucket=residuals,
+        bucket_by_entity=buckets,
+    )
+
+    assert (summary["p10"] <= summary["p50"]).all()
+    assert (summary["p50"] <= summary["p90"]).all()
+    assert (summary["stddev"] >= 0.0).all()

--- a/tests/fantasy/adapters/test_mlb_projection_phase15_calibration.py
+++ b/tests/fantasy/adapters/test_mlb_projection_phase15_calibration.py
@@ -1,0 +1,114 @@
+"""Phase 1.5b uncertainty and calibration tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def test_hit_rate_uncertainty_residual_scale_changes_interval_width() -> None:
+    from src.fantasy.adapters.mlb.uncertainty import (
+        summarize_hit_rate_uncertainty_from_counts,
+    )
+
+    hit_mean = pd.Series([120.0], index=["p1"], dtype="float64")
+    pa_mean = pd.Series([400.0], index=["p1"], dtype="float64")
+    sample_sizes = pd.Series([1.0], index=["p1"], dtype="float64")
+    hit_residuals = pd.Series([-20.0, -10.0, 10.0, 20.0], dtype="float64")
+    pa_residuals = pd.Series([-50.0, -25.0, 25.0, 50.0], dtype="float64")
+
+    wide = summarize_hit_rate_uncertainty_from_counts(
+        hit_mean_by_entity=hit_mean,
+        pa_mean_by_entity=pa_mean,
+        sample_size_by_entity=sample_sizes,
+        hit_residuals=hit_residuals,
+        pa_residuals=pa_residuals,
+        seed=2026,
+        draws=2000,
+        residual_scale_global=1.0,
+    )
+    narrow = summarize_hit_rate_uncertainty_from_counts(
+        hit_mean_by_entity=hit_mean,
+        pa_mean_by_entity=pa_mean,
+        sample_size_by_entity=sample_sizes,
+        hit_residuals=hit_residuals,
+        pa_residuals=pa_residuals,
+        seed=2026,
+        draws=2000,
+        residual_scale_global=0.25,
+    )
+
+    wide_width = float(wide.loc["p1", "p90"] - wide.loc["p1", "p10"])
+    narrow_width = float(narrow.loc["p1", "p90"] - narrow.loc["p1", "p10"])
+
+    assert (
+        0.0
+        <= float(wide.loc["p1", "p10"])
+        <= float(wide.loc["p1", "p50"])
+        <= float(wide.loc["p1", "p90"])
+        <= 1.0
+    )
+    assert (
+        0.0
+        <= float(narrow.loc["p1", "p10"])
+        <= float(narrow.loc["p1", "p50"])
+        <= float(narrow.loc["p1", "p90"])
+        <= 1.0
+    )
+    assert narrow_width < wide_width
+
+
+def test_hit_rate_uncertainty_bucket_fallback_uses_default_when_sparse() -> None:
+    from src.fantasy.adapters.mlb.uncertainty import (
+        summarize_hit_rate_uncertainty_from_counts,
+    )
+
+    hit_mean = pd.Series([120.0], index=["p1"], dtype="float64")
+    pa_mean = pd.Series([400.0], index=["p1"], dtype="float64")
+    sample_sizes = pd.Series([1.0], index=["p1"], dtype="float64")
+
+    output = summarize_hit_rate_uncertainty_from_counts(
+        hit_mean_by_entity=hit_mean,
+        pa_mean_by_entity=pa_mean,
+        sample_size_by_entity=sample_sizes,
+        hit_residuals=pd.Series([-15.0, 15.0, -10.0, 10.0, 0.0], dtype="float64"),
+        pa_residuals=pd.Series([-40.0, 40.0, -20.0, 20.0, 0.0], dtype="float64"),
+        hit_residuals_by_bucket={"sparse": pd.Series([0.0], dtype="float64")},
+        pa_residuals_by_bucket={"sparse": pd.Series([0.0], dtype="float64")},
+        bucket_by_entity=pd.Series(["sparse"], index=["p1"]),
+        min_bucket_residual_count=5,
+        seed=2026,
+        draws=1500,
+    )
+
+    width = float(output.loc["p1", "p90"] - output.loc["p1", "p10"])
+    assert width > 0.0
+
+
+def test_red_flag_dashboard_emits_phase15b_calibration_columns() -> None:
+    from src.fantasy.adapters.mlb.backtest import build_hit_rate_red_flag_dashboard
+
+    predictions = pd.DataFrame(
+        {
+            "entity_id": ["a", "b", "c"],
+            "fold": ["2025", "2025", "2025"],
+            "metric_id": ["hit_rate", "hit_rate", "hit_rate"],
+            "prediction": [0.30, 0.24, 0.28],
+            "actual": [0.35, 0.25, 0.26],
+            "p10": [0.20, 0.18, 0.20],
+            "p90": [0.42, 0.36, 0.34],
+        }
+    )
+
+    summary = build_hit_rate_red_flag_dashboard(predictions, coverage_target=0.80)
+
+    row = summary.iloc[0]
+    assert "hit_rate_interval_width_median" in summary.columns
+    assert "hit_rate_interval_width_p95" in summary.columns
+    assert "hit_rate_coverage_error_vs_target" in summary.columns
+    assert float(row["hit_rate_interval_width_median"]) > 0.0
+    assert float(row["hit_rate_interval_width_p95"]) >= float(
+        row["hit_rate_interval_width_median"]
+    )
+    assert float(row["hit_rate_coverage_error_vs_target"]) == abs(
+        float(row["hit_rate_coverage"]) - 0.80
+    )

--- a/tests/fantasy/adapters/test_mlb_projection_phase15_features.py
+++ b/tests/fantasy/adapters/test_mlb_projection_phase15_features.py
@@ -69,3 +69,99 @@ def test_snapshot_builder_generates_rest_of_season_target() -> None:
     assert "season_to_date_hits" in snapshots.columns
     assert "target_rest_of_season_hits" in snapshots.columns
     assert float(first["target_rest_of_season_hits"]) >= 0.0
+
+
+def test_hits_pa_training_view_applies_regular_season_dedup_and_constraints() -> None:
+    from src.fantasy.adapters.mlb.datasets import build_hits_pa_training_view
+
+    frame = pd.DataFrame(
+        {
+            "game_pk": [1, 1, 1, 2],
+            "batter": ["42", "42", "42", "42"],
+            "game_date": ["2025-04-01", "2025-04-01", "2025-04-01", "2025-04-02"],
+            "at_bat_number": [10, 10, 11, 12],
+            "pitch_number": [1, 2, 1, 1],
+            "game_type": ["R", "R", "R", "S"],
+            "events": ["none", "single", "walk", "single"],
+            "pitcher_throws": ["R", "R", "L", "R"],
+            "launch_speed": [70.0, 101.0, 82.0, 99.0],
+        }
+    )
+
+    cleaned = build_hits_pa_training_view(
+        frame,
+        entity_id_col="batter",
+        date_col="game_date",
+        regular_season_only=True,
+        require_batter_pa_dedup=True,
+    )
+
+    assert set(cleaned.columns).issuperset(
+        {"is_regular_season", "pa_terminal_dedup_applied", "qa_invalid_row_flag"}
+    )
+    assert cleaned["is_regular_season"].all()
+    # Two regular-season terminal PA rows survive for 2025-04-01:
+    # at_bat_number=10 -> single, at_bat_number=11 -> walk.
+    row = cleaned.iloc[0]
+    assert float(row["plate_appearances"]) == 2.0
+    assert float(row["hits"]) == 1.0
+    assert float(row["hits"]) <= float(row["plate_appearances"])
+
+
+def test_snapshot_builder_includes_anchor_day_in_future_target() -> None:
+    from src.fantasy.adapters.mlb.datasets import build_player_season_snapshots
+
+    frame = pd.DataFrame(
+        {
+            "batter": ["10", "10", "10"],
+            "game_date": ["2025-04-01", "2025-04-02", "2025-04-03"],
+            "season": [2025, 2025, 2025],
+            "plate_appearances": [4.0, 4.0, 4.0],
+            "hits": [1.0, 2.0, 3.0],
+            "total_bases": [1.0, 2.0, 3.0],
+            "walks": [0.0, 0.0, 0.0],
+            "strikeouts": [1.0, 1.0, 1.0],
+            "hard_hit_events": [1.0, 1.0, 1.0],
+            "pa_vs_lhp": [1.0, 1.0, 1.0],
+            "pa_vs_rhp": [3.0, 3.0, 3.0],
+        }
+    )
+
+    snapshots = build_player_season_snapshots(
+        frame,
+        entity_id_col="batter",
+        date_col="game_date",
+        target_col="hits",
+        snapshot_min_games=1,
+        snapshot_anchor_frequency="daily",
+    )
+
+    row = snapshots[snapshots["anchor_date"] == "2025-04-02"].iloc[0]
+    assert float(row["season_to_date_hits"]) == 1.0
+    # Anchor-day hit total (2.0) should be included in future label.
+    assert float(row["target_rest_of_season_hits"]) == 5.0
+
+
+def test_hits_pa_training_view_uses_hard_hit_rate_fallback_without_statcast() -> None:
+    from src.fantasy.adapters.mlb.datasets import build_hits_pa_training_view
+
+    frame = pd.DataFrame(
+        {
+            "batter": ["42"],
+            "game_date": ["2025-04-01"],
+            "plate_appearances": [4.0],
+            "hits": [1.0],
+            "hard_hit_rate": [0.5],
+        }
+    )
+
+    cleaned = build_hits_pa_training_view(
+        frame,
+        entity_id_col="batter",
+        date_col="game_date",
+        regular_season_only=True,
+        require_batter_pa_dedup=True,
+    )
+
+    row = cleaned.iloc[0]
+    assert float(row["hard_hit_events"]) == 2.0

--- a/tests/fantasy/adapters/test_mlb_projection_phase15_features.py
+++ b/tests/fantasy/adapters/test_mlb_projection_phase15_features.py
@@ -1,0 +1,71 @@
+"""Phase 1.5 feature engineering and snapshot dataset tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def test_shifted_rolling_features_are_leakage_safe() -> None:
+    from src.fantasy.adapters.mlb.feature_engineering import (
+        add_phase15_rolling_features,
+    )
+
+    frame = pd.DataFrame(
+        {
+            "batter": ["42", "42", "42"],
+            "game_date": ["2025-04-01", "2025-04-02", "2025-04-03"],
+            "hits": [1.0, 3.0, 100.0],
+            "plate_appearances": [4.0, 4.0, 4.0],
+            "total_bases": [2.0, 4.0, 12.0],
+            "walks": [0.0, 1.0, 0.0],
+            "strikeouts": [1.0, 0.0, 0.0],
+            "hard_hit_events": [1.0, 1.0, 4.0],
+        }
+    )
+
+    engineered = add_phase15_rolling_features(
+        frame,
+        entity_id_col="batter",
+        date_col="game_date",
+    )
+
+    third_row = engineered.iloc[2]
+    # Shifted rolling mean should only use rows before 2025-04-03.
+    assert float(third_row["roll_7_hits"]) == 2.0
+
+
+def test_snapshot_builder_generates_rest_of_season_target() -> None:
+    from src.fantasy.adapters.mlb.datasets import build_player_season_snapshots
+
+    frame = pd.DataFrame(
+        {
+            "batter": ["10", "10", "10", "10"],
+            "game_date": ["2025-04-01", "2025-04-08", "2025-05-01", "2025-06-01"],
+            "season": [2025, 2025, 2025, 2025],
+            "plate_appearances": [4.0, 5.0, 4.0, 4.0],
+            "hits": [1.0, 2.0, 1.0, 3.0],
+            "total_bases": [2.0, 3.0, 2.0, 5.0],
+            "walks": [0.0, 1.0, 0.0, 1.0],
+            "strikeouts": [1.0, 1.0, 0.0, 1.0],
+            "hard_hit_events": [1.0, 1.0, 1.0, 2.0],
+            "pa_vs_lhp": [1.0, 2.0, 1.0, 2.0],
+            "pa_vs_rhp": [3.0, 3.0, 3.0, 2.0],
+            "hard_hit_rate": [0.25, 0.2, 0.25, 0.5],
+        }
+    )
+
+    snapshots = build_player_season_snapshots(
+        frame,
+        entity_id_col="batter",
+        date_col="game_date",
+        target_col="hits",
+        snapshot_min_games=1,
+        snapshot_anchor_frequency="weekly",
+    )
+
+    assert not snapshots.empty
+    first = snapshots.iloc[0]
+    assert "anchor_date" in snapshots.columns
+    assert "season_to_date_hits" in snapshots.columns
+    assert "target_rest_of_season_hits" in snapshots.columns
+    assert float(first["target_rest_of_season_hits"]) >= 0.0

--- a/tests/fantasy/adapters/test_mlb_projection_phase15_priors.py
+++ b/tests/fantasy/adapters/test_mlb_projection_phase15_priors.py
@@ -1,0 +1,89 @@
+"""Phase 1.5 pybaseball priors tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+PRIOR_COLUMNS = ["prior_pa", "prior_bb_rate", "prior_k_rate"]
+
+
+def test_join_priors_uses_league_median_fallback_for_missing_ids() -> None:
+    from src.fantasy.adapters.mlb.priors import attach_priors_to_snapshots
+
+    snapshots = pd.DataFrame(
+        {
+            "entity_id": ["101", "202"],
+            "fg_id": [11, 99],
+            "season": [2025, 2025],
+        }
+    )
+    priors = pd.DataFrame(
+        {
+            "fg_id": [11],
+            "season": [2025],
+            "prior_pa": [600.0],
+            "prior_bb_rate": [0.09],
+            "prior_k_rate": [0.21],
+        }
+    )
+
+    enriched = attach_priors_to_snapshots(
+        snapshots=snapshots,
+        priors=priors,
+        prior_columns=tuple(PRIOR_COLUMNS),
+    )
+
+    present = enriched[enriched["fg_id"] == 11].iloc[0]
+    missing = enriched[enriched["fg_id"] == 99].iloc[0]
+
+    assert float(present["prior_pa"]) == 600.0
+    assert int(present["prior_imputed_flag"]) == 0
+    assert float(missing["prior_pa"]) == 600.0
+    assert int(missing["prior_imputed_flag"]) == 1
+
+
+def test_load_cached_priors_reads_parquet_without_network(tmp_path) -> None:
+    from src.fantasy.adapters.mlb.priors import load_cached_priors
+
+    expected = pd.DataFrame(
+        {
+            "fg_id": [11],
+            "season": [2025],
+            "prior_pa": [620.0],
+        }
+    )
+    cache_path = tmp_path / "priors.parquet"
+    expected.to_parquet(cache_path, index=False)
+
+    loaded = load_cached_priors(str(cache_path))
+
+    pd.testing.assert_frame_equal(loaded, expected)
+
+
+def test_join_priors_without_fg_id_does_not_duplicate_rows() -> None:
+    from src.fantasy.adapters.mlb.priors import attach_priors_to_snapshots
+
+    snapshots = pd.DataFrame(
+        {
+            "entity_id": ["a", "b"],
+            "season": [2025, 2025],
+        }
+    )
+    priors = pd.DataFrame(
+        {
+            "fg_id": [11, 12],
+            "season": [2025, 2025],
+            "prior_pa": [500.0, 600.0],
+            "prior_bb_rate": [0.08, 0.10],
+            "prior_k_rate": [0.20, 0.22],
+        }
+    )
+
+    enriched = attach_priors_to_snapshots(
+        snapshots=snapshots,
+        priors=priors,
+        prior_columns=tuple(PRIOR_COLUMNS),
+    )
+
+    assert len(enriched) == len(snapshots)
+    assert (enriched["prior_imputed_flag"] == 1).all()


### PR DESCRIPTION
## Summary
- harden the MLB Phase 1.5 hit-rate family by fixing upstream hits and plate-appearance training paths
- add leakage-safe snapshot/data cleaning fixes, count-derived hit-rate uncertainty calibration, and model-selection anti-churn controls
- move the Phase 1.5a plan into implemented docs, archive pre-fix findings, and add the in-progress Phase 1.5b plan

## Risks
- Phase 1.5b is intentionally not complete yet; comparator artifact freezing, ablation artifacts, and full acceptance reruns remain follow-up work
- changes are concentrated in the MLB fantasy adapter path and should not affect existing MLB/NFL/NHL sportsbook pipelines

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q`
- local result: `306 passed`
- workflow run: CI will attach to this PR after creation

## Test-First Evidence
- regression coverage added for the anchor-day snapshot-label bug and hard-hit-rate fallback bug in `tests/fantasy/adapters/test_mlb_projection_phase15_features.py`
- calibration coverage added for residual scaling, sparse-bucket fallback, and dashboard metrics in `tests/fantasy/adapters/test_mlb_projection_phase15_calibration.py`
- current branch is GREEN via the validation commands above; I did not rerun the historical pre-fix revision in this session
