### PR TITLE
MLB live proof-run hardening and slip tooling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,210 @@
+# Sportsbalf
+
+Sportsbalf produces model-driven betting analysis artifacts for supported sports and markets. In the MLB Underdog workflow, the system scores live slates and emits reviewable slip artifacts for human action, not account automation.
+
+## Language
+
+**Shadow Run**:
+A manual workflow that fetches live lines, scores a slate, and writes artifacts without placing picks.
+_Avoid_: Auto-submit, autobet, live execution
+
+**Live Line Snapshot**:
+A dated file containing normalized sportsbook lines for one stat on one slate.
+_Avoid_: Raw payload, permanent source of truth
+
+**Candidate Leg**:
+A single scored over/under prop that is eligible to be combined into a slip.
+_Avoid_: Slip, betslip
+
+**Slip Artifact**:
+A generated JSON representation of one or more candidate legs proposed for manual review.
+_Avoid_: Submitted entry, placed pick
+
+**Manual Submission**:
+Human entry of a reviewed slip artifact into Underdog outside this repository.
+_Avoid_: Automated submission, account automation
+
+**Proof Run**:
+A fast shadow run used to verify that the live workflow produces scored candidates and slip artifacts with the current code and models.
+_Avoid_: Freshness run, betting recommendation run
+
+**Freshness Run**:
+A shadow run performed only after current-season inputs and models have been refreshed for recommendation-quality output.
+_Avoid_: Smoke test, proof run
+
+**Debug Run**:
+A targeted live-shadow run used to inspect specific markets or overrides without claiming proof-run validity.
+_Avoid_: Proof run, recommendation run
+
+**Sanity Check Failure**:
+A proof-run outcome where artifacts may exist but the candidate pool shows signs of pipeline corruption or implausible model behavior.
+_Avoid_: Benign warning, acceptable partial failure
+
+**Stat-Mix Gate**:
+A hard proof-run check that fails when candidate-leg coverage is implausibly dominated by one stat.
+_Avoid_: Normal slate imbalance, diversity preference
+
+**Confidence Gate**:
+A hard proof-run check that fails when model probabilities or EV values are implausibly extreme.
+_Avoid_: Aggressive but plausible edge, ranking preference
+
+**Slip-Eligible Pool**:
+The ranked candidate-leg pool remaining after normalization and EV-based filtering that is actually considered for slip construction.
+_Avoid_: Full scored slate, raw provider payload
+
+**Proof-Run Verdict**:
+An explicit pass/fail outcome for a proof run derived from runtime completion and sanity-gate results.
+_Avoid_: Implicit interpretation, operator guesswork
+
+**Proof-Run Failure Reason**:
+A structured explanation attached to a failed proof-run verdict that identifies the blocking class of problem.
+_Avoid_: Freeform log spelunking, unlabeled failure
+
+**Proof-Run Evidence**:
+The compact summary data emitted with a proof-run verdict so the operator can distinguish healthy output, abstention, and pipeline breakage.
+_Avoid_: Raw artifact inspection, vague pass/fail
+
+**No-Play Slate**:
+A healthy run outcome where candidates were scored but no slip should be manually submitted because the slate does not justify one under current rules.
+_Avoid_: Runtime failure, broken pipeline
+
+## Relationships
+
+- A **Shadow Run** produces one or more **Live Line Snapshots**
+- A **Shadow Run** scores **Candidate Legs** from the current slate
+- A **Slip Artifact** contains one or more **Candidate Legs**
+- A **Manual Submission** may be based on a reviewed **Slip Artifact**
+- A **Proof Run** is a kind of **Shadow Run**
+- A **Freshness Run** is a kind of **Shadow Run**
+- A **Freshness Run** may follow a successful **Proof Run**
+- A **Debug Run** is a kind of **Shadow Run**
+- A **Sanity Check Failure** makes a **Proof Run** unsuccessful even if **Slip Artifacts** were written
+- A **Stat-Mix Gate** is one kind of **Sanity Check Failure**
+- A **Confidence Gate** is one kind of **Sanity Check Failure**
+- The **Stat-Mix Gate** and **Confidence Gate** inspect the **Slip-Eligible Pool**
+- The **Stat-Mix Gate** fails when any one stat exceeds 70% of the **Slip-Eligible Pool**, subject to later tuning
+- The **Confidence Gate** evaluates both probability and EV extremes in the **Slip-Eligible Pool**
+- The initial probability extreme for the **Confidence Gate** is any leg with probability at or above 0.80 or at or below 0.20, subject to later calibration from historical data
+- The initial EV extreme for the **Confidence Gate** is any leg with EV at or above 0.35, subject to later calibration from historical data
+- A **Proof Run** should emit an explicit **Proof-Run Verdict**
+- A failed **Proof-Run Verdict** should include one or more structured **Proof-Run Failure Reason** values
+- Initial **Proof-Run Failure Reason** values should be broad buckets with supporting evidence, not fully granular threshold-specific schemas
+- Partial stat failures remain acceptable in a **Proof Run** unless they prevent a non-empty **Slip-Eligible Pool** and at least one valid **Slip Artifact**
+- A **No-Play Slate** is distinct from a failed **Proof Run**
+- A **No-Play Slate** still counts as a successful **Proof-Run Verdict** when runtime and sanity gates pass
+- A **No-Play Slate** should appear as its own explicit outcome in proof-run summaries
+- **Proof Run** hardening and **Freshness Run** hardening should be planned separately
+- **Proof Run** hardening should extend the existing MLB live shadow CLI rather than introduce a second command
+- **Proof-Run Verdict** and proof-run sanity gates should run by default in the existing MLB live shadow CLI
+- Every **Proof-Run Verdict** should emit **Proof-Run Evidence** including outcome, failure reasons when present, stat completion/failure summaries, slip-eligible pool size, stat mix, probability extremes, EV extreme, and slip counts
+- MLB live shadow runs should default to `mlb.live_underdog.stat_ids` from config, with CLI `--stat-id` values acting as overrides
+- Missing required config-backed MLB live stat ids should hard-fail the **Proof-Run Verdict** before runtime scoring begins
+- Required MLB live stat-id coverage for a **Proof Run** means all currently supported MLB pitcher-prop markets, not a partial subset
+- The MLB live shadow CLI should support explicit **Proof Run** and **Debug Run** modes
+- A **Debug Run** may use subset stat-id overrides without claiming full proof-run validity
+- **Proof Run** and **Debug Run** should share one summary schema with an explicit mode field
+
+## Example dialogue
+
+> **Dev:** "Does this MLB flow submit slips?"
+> **Domain expert:** "No. A **Shadow Run** only creates **Slip Artifacts** for **Manual Submission**."
+
+> **Dev:** "Can I bet after a **Proof Run**?"
+> **Domain expert:** "Not yet. A **Proof Run** verifies the workflow; a **Freshness Run** is the bar for recommendation-quality output."
+
+> **Dev:** "The run wrote JSON slips. Did it pass?"
+> **Domain expert:** "Not if a **Sanity Check Failure** shows the candidate pool is implausible."
+
+> **Dev:** "What makes a proof run fail even with artifacts?"
+> **Domain expert:** "A **Stat-Mix Gate** or **Confidence Gate** can still make the run unsuccessful."
+
+> **Dev:** "Do those checks look at every scored row?"
+> **Domain expert:** "No. They inspect the **Slip-Eligible Pool**, because that is what manual submission is based on."
+
+> **Dev:** "What counts as stat dominance for now?"
+> **Domain expert:** "If one stat exceeds 70% of the **Slip-Eligible Pool**, the **Stat-Mix Gate** fails."
+
+> **Dev:** "Does the confidence gate look at just probabilities?"
+> **Domain expert:** "No. The **Confidence Gate** uses both probability and EV extremes."
+
+> **Dev:** "Are the probability thresholds final?"
+> **Domain expert:** "No. They are a sane starting point for the **Confidence Gate** until historical calibration tightens them."
+
+> **Dev:** "What about EV extremes?"
+> **Domain expert:** "Treat any slip-eligible leg with EV >= 0.35 as a first-pass **Confidence Gate** failure until historical data supports a better threshold."
+
+> **Dev:** "How do I know the proof run passed?"
+> **Domain expert:** "The workflow should emit an explicit **Proof-Run Verdict**, not force manual interpretation."
+
+> **Dev:** "If it fails, how specific should the output be?"
+> **Domain expert:** "A failed **Proof-Run Verdict** should include structured **Proof-Run Failure Reason** values so the next fix is obvious."
+
+> **Dev:** "How detailed should those reasons be at first?"
+> **Domain expert:** "Use broad **Proof-Run Failure Reason** buckets first, then attach compact evidence."
+
+> **Dev:** "When does a degraded run become a runtime failure?"
+> **Domain expert:** "Only when partial failures prevent a non-empty **Slip-Eligible Pool** and at least one valid **Slip Artifact**."
+
+> **Dev:** "What if there are scored candidates but the right move is to bet nothing?"
+> **Domain expert:** "That is a **No-Play Slate**, not a failed proof run."
+
+> **Dev:** "Does a no-play slate fail the proof run?"
+> **Domain expert:** "No. A **No-Play Slate** still passes the **Proof-Run Verdict** if the workflow and sanity gates are healthy."
+
+> **Dev:** "Should no-play look the same as an ordinary pass?"
+> **Domain expert:** "No. A **No-Play Slate** should be explicit in the summary so healthy abstention is distinguishable from accidental emptiness."
+
+> **Dev:** "Should proof-run hardening and freshness work live in one plan?"
+> **Domain expert:** "No. **Proof Run** hardening and **Freshness Run** hardening should be separate plans."
+
+> **Dev:** "Should proof-run hardening add a new command?"
+> **Domain expert:** "No. It should extend the existing MLB live shadow CLI."
+
+> **Dev:** "Should proof-run checks be opt-in?"
+> **Domain expert:** "No. The existing MLB live shadow CLI should run the **Proof-Run Verdict** and sanity gates by default."
+
+> **Dev:** "What should the proof-run summary show?"
+> **Domain expert:** "It should emit compact **Proof-Run Evidence** so the operator can see pass, fail, or no-play without opening raw JSON."
+
+> **Dev:** "Where should live Underdog stat ids come from by default?"
+> **Domain expert:** "From config. CLI `--stat-id` values should only override config for one-off runs."
+
+> **Dev:** "What if config is missing one of the live stat ids?"
+> **Domain expert:** "That should hard-fail the **Proof-Run Verdict** before the run starts."
+
+> **Dev:** "How many MLB live markets are required for a proof run?"
+> **Domain expert:** "All currently supported MLB pitcher-prop markets."
+
+> **Dev:** "Why keep CLI stat-id overrides if proof runs need full coverage?"
+> **Domain expert:** "Because subset overrides belong to a **Debug Run**, not a **Proof Run**."
+
+> **Dev:** "Should proof and debug runs write different summary formats?"
+> **Domain expert:** "No. They should share one summary schema with an explicit mode field."
+
+## Flagged ambiguities
+
+- "submit UD betslips" was ambiguous between **Manual Submission** and automated placement — resolved: this repo only supports **Manual Submission**.
+- "prove the model" was ambiguous between workflow validation and recommendation readiness — resolved: **Proof Run** validates workflow, **Freshness Run** gates recommendation-quality use.
+- "successful proof run" was ambiguous between artifact creation and trustworthy output — resolved: **Sanity Check Failure** means the **Proof Run** failed even if artifacts were produced.
+- "additional checks on correctness" was vague — resolved: the first hard proof-run correctness checks are the **Stat-Mix Gate** and **Confidence Gate**.
+- "candidate pool" was ambiguous between all scored rows and actionable rows — resolved: proof-run sanity checks inspect the **Slip-Eligible Pool**.
+- "too much stat dominance" was unresolved — resolved: the initial **Stat-Mix Gate** threshold is 70% of the **Slip-Eligible Pool** for any one stat.
+- "confidence extremes" was underspecified — resolved: the **Confidence Gate** inspects both probability and EV in the **Slip-Eligible Pool**.
+- "extreme probability" had no threshold — resolved: the initial **Confidence Gate** probability bounds are `prob <= 0.20` or `prob >= 0.80`, pending historical calibration.
+- "extreme EV" had no threshold — resolved: the initial **Confidence Gate** EV bound is `ev >= 0.35`, pending historical calibration.
+- "did the proof run pass?" was too implicit — resolved: the workflow should emit an explicit **Proof-Run Verdict**.
+- "failed proof run" was too coarse — resolved: failed proof runs should include structured **Proof-Run Failure Reason** values.
+- "how detailed should failure reasons be?" was unresolved — resolved: initial **Proof-Run Failure Reason** values should be broad buckets with compact evidence.
+- "when do partial failures become blocking?" was unresolved — resolved: a degraded proof run is acceptable unless it cannot produce a non-empty **Slip-Eligible Pool** and at least one valid **Slip Artifact**.
+- "no valid slips" was overloaded between broken workflow and healthy abstention — resolved: a healthy abstention outcome is a **No-Play Slate**, not a proof-run failure.
+- "does no action mean failure?" was unresolved — resolved: a healthy **No-Play Slate** is still a successful **Proof-Run Verdict**.
+- "how should abstention appear in output?" was unresolved — resolved: **No-Play Slate** should be an explicit summary outcome, not an implied zero-slip pass.
+- "should proof and freshness share one plan?" was unresolved — resolved: **Proof Run** hardening and **Freshness Run** hardening should be planned separately.
+- "should proof-run hardening use a new command?" was unresolved — resolved: it should extend the existing MLB live shadow CLI.
+- "should proof-run checks be opt-in?" was unresolved — resolved: proof-run verdicts and sanity gates should run by default in the existing MLB live shadow CLI.
+- "what should the proof-run summary contain?" was unresolved — resolved: every verdict should emit compact **Proof-Run Evidence** with outcome, reasons, completion stats, pool shape, confidence extremes, and slip counts.
+- "where should live stat ids come from?" was unresolved — resolved: MLB live shadow runs should default to config-backed stat ids, with CLI values used only as overrides.
+- "are missing config stat ids acceptable degradation?" was unresolved — resolved: missing required config-backed MLB live stat ids should hard-fail the **Proof-Run Verdict** before scoring begins.
+- "what counts as required live coverage?" was unresolved — resolved: a **Proof Run** requires stat-id coverage for all currently supported MLB pitcher-prop markets.
+- "why keep subset stat-id overrides?" was unresolved — resolved: subset overrides are for **Debug Run** mode, while **Proof Run** keeps the full-market coverage contract.
+- "should proof and debug summaries diverge?" was unresolved — resolved: they should share one summary schema with an explicit mode field.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ MLB live shadow run:
 This writes dated live line snapshots under `data/lines/` and JSON slip
 artifacts plus a run summary under `betslips/mlb_live/` by default.
 
+Print a saved live summary in app-entry format:
+
+```bash
+.venv/bin/python scripts/print_slips.py betslips/mlb_live/mlb_live_2026-05-14_summary.json
+.venv/bin/python scripts/print_slips.py betslips/mlb_live/mlb_live_2026-05-14_summary.json --tag fullsend
+```
+
 ### 3) Validate Changes
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ Force retrain before inference:
 .venv/bin/python -m pipeline.main --sport nhl --stat shots_on_goal --config config/nhl.yaml --retrain
 ```
 
+MLB live shadow run:
+
+```bash
+.venv/bin/python scripts/build_mlb_live_betslips.py \
+  --config config/mlb.yaml \
+  --stat-id strikeouts=PickemStat_... \
+  --stat-id outs_recorded=PickemStat_... \
+  --stat-id earned_runs=PickemStat_... \
+  --stat-id hits_allowed=PickemStat_... \
+  --stat-id bb_allowed=PickemStat_...
+```
+
+This writes dated live line snapshots under `data/lines/` and JSON slip
+artifacts plus a run summary under `betslips/mlb_live/` by default.
+
 ### 3) Validate Changes
 
 ```bash

--- a/config/mlb.yaml
+++ b/config/mlb.yaml
@@ -217,3 +217,17 @@ mlb:
     allow_missing_lines: true
     park_factor_min_samples: 20
     park_factor_half_life_games: 60
+  live_underdog:
+    stat_ids:
+      strikeouts: PickemStat_de868934-c920-405c-b827-693c15aa47a1
+      outs_recorded: PickemStat_0f4a1b3d-62d9-47f8-9f45-7c2ddf6c8d8e
+      earned_runs: PickemStat_a2f0d1e5-4c4a-4f4c-98f2-8f0f88f7a3d1
+      hits_allowed: PickemStat_9e7e7cb2-58a3-4a3f-86f2-6f07d7dd4d55
+      bb_allowed: PickemStat_7c1f6a0d-0f25-4e1d-8ce8-0c82ff1b0f44
+    snapshot_output_dir: data/lines
+    snapshot_filename_template: "{stat}_{date}.csv"
+    orchestration_defaults:
+      same_pitcher_stacking: true
+      min_players_per_slip: 2
+      min_teams_per_slip: 2
+      json_only: true

--- a/config/mlb.yaml
+++ b/config/mlb.yaml
@@ -4,16 +4,17 @@ pipeline:
 
 mlb:
   strikeouts:
-    lines_path: data/lines/strikeouts_2025-09-20.csv
+    lines_path: data/lines/strikeouts_2026-04-24.csv
     game_logs_path: tests/testdata/game_logs.csv
-    park_factors_path: data/raw/park_factors_2025.csv
-    pitch_data_path: data/processed/pitcher_game_data_2025.parquet
+    park_factors_path: data/raw/park_factors_2026.csv
+    pitch_data_path: data/processed/pitcher_game_data_2026.parquet
     training_data_paths:
       - data/processed/pitcher_game_data_2021.parquet
       - data/processed/pitcher_game_data_2022.parquet
       - data/processed/pitcher_game_data_2023.parquet
       - data/processed/pitcher_game_data_2024.parquet
       - data/processed/pitcher_game_data_2025.parquet
+      - data/processed/pitcher_game_data_2026.parquet
     model_path: models/xgb_tuned_pitcher_k_model.joblib
     model_selection:
       enabled: true
@@ -58,16 +59,17 @@ mlb:
         primary_source: pybaseball_team_game_logs
         secondary_source: statsapi_game_feed
   outs_recorded:
-    lines_path: data/lines/outs_recorded_2025-09-22.csv
-    pitch_data_path: data/raw/statcast/statcast_raw_2025.parquet
+    lines_path: data/lines/outs_recorded_2026-04-24.csv
+    pitch_data_path: data/raw/statcast/statcast_raw_2026.parquet
     training_data_paths:
       - data/raw/statcast/statcast_raw_2021.parquet
       - data/raw/statcast/statcast_raw_2022.parquet
       - data/raw/statcast/statcast_raw_2023.parquet
       - data/raw/statcast/statcast_raw_2024.parquet
       - data/raw/statcast/statcast_raw_2025.parquet
-    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2025.parquet
-    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2025.parquet
+      - data/raw/statcast/statcast_raw_2026.parquet
+    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2026.parquet
+    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2026.parquet
     model_path: models/mlb_outs_recorded_xgb.joblib
     model_selection:
       enabled: true
@@ -98,16 +100,17 @@ mlb:
     park_factor_min_samples: 20
     park_factor_half_life_games: 60
   earned_runs:
-    lines_path: data/lines/earned_runs_2025-09-22.csv
-    pitch_data_path: data/raw/statcast/statcast_raw_2025.parquet
+    lines_path: data/lines/earned_runs_2026-04-24.csv
+    pitch_data_path: data/raw/statcast/statcast_raw_2026.parquet
     training_data_paths:
       - data/raw/statcast/statcast_raw_2021.parquet
       - data/raw/statcast/statcast_raw_2022.parquet
       - data/raw/statcast/statcast_raw_2023.parquet
       - data/raw/statcast/statcast_raw_2024.parquet
       - data/raw/statcast/statcast_raw_2025.parquet
-    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2025.parquet
-    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2025.parquet
+      - data/raw/statcast/statcast_raw_2026.parquet
+    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2026.parquet
+    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2026.parquet
     model_path: models/mlb_earned_runs_xgb.joblib
     model_selection:
       enabled: true
@@ -138,16 +141,17 @@ mlb:
     park_factor_min_samples: 20
     park_factor_half_life_games: 60
   hits_allowed:
-    lines_path: data/lines/hits_allowed_2025-09-22.csv
-    pitch_data_path: data/raw/statcast/statcast_raw_2025.parquet
+    lines_path: data/lines/hits_allowed_2026-04-24.csv
+    pitch_data_path: data/raw/statcast/statcast_raw_2026.parquet
     training_data_paths:
       - data/raw/statcast/statcast_raw_2021.parquet
       - data/raw/statcast/statcast_raw_2022.parquet
       - data/raw/statcast/statcast_raw_2023.parquet
       - data/raw/statcast/statcast_raw_2024.parquet
       - data/raw/statcast/statcast_raw_2025.parquet
-    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2025.parquet
-    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2025.parquet
+      - data/raw/statcast/statcast_raw_2026.parquet
+    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2026.parquet
+    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2026.parquet
     model_path: models/mlb_hits_allowed_xgb.joblib
     model_selection:
       enabled: true
@@ -178,16 +182,17 @@ mlb:
     park_factor_min_samples: 20
     park_factor_half_life_games: 60
   bb_allowed:
-    lines_path: data/lines/bb_allowed_2025-09-22.csv
-    pitch_data_path: data/raw/statcast/statcast_raw_2025.parquet
+    lines_path: data/lines/bb_allowed_2026-04-24.csv
+    pitch_data_path: data/raw/statcast/statcast_raw_2026.parquet
     training_data_paths:
       - data/raw/statcast/statcast_raw_2021.parquet
       - data/raw/statcast/statcast_raw_2022.parquet
       - data/raw/statcast/statcast_raw_2023.parquet
       - data/raw/statcast/statcast_raw_2024.parquet
       - data/raw/statcast/statcast_raw_2025.parquet
-    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2025.parquet
-    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2025.parquet
+      - data/raw/statcast/statcast_raw_2026.parquet
+    pitcher_dataset_output_path: data/processed/mlb_pitcher_games_multi_target_2026.parquet
+    batter_dataset_output_path: data/processed/mlb_batter_games_foundation_2026.parquet
     model_path: models/mlb_bb_allowed_xgb.joblib
     model_selection:
       enabled: true
@@ -219,11 +224,11 @@ mlb:
     park_factor_half_life_games: 60
   live_underdog:
     stat_ids:
-      strikeouts: PickemStat_de868934-c920-405c-b827-693c15aa47a1
-      outs_recorded: PickemStat_0f4a1b3d-62d9-47f8-9f45-7c2ddf6c8d8e
-      earned_runs: PickemStat_a2f0d1e5-4c4a-4f4c-98f2-8f0f88f7a3d1
-      hits_allowed: PickemStat_9e7e7cb2-58a3-4a3f-86f2-6f07d7dd4d55
-      bb_allowed: PickemStat_7c1f6a0d-0f25-4e1d-8ce8-0c82ff1b0f44
+      strikeouts: PickemStat_311b6775-4d03-4466-8ab9-776442468b27
+      outs_recorded: PickemStat_a74cd651-437c-4e6c-b011-c58789b09db7
+      earned_runs: PickemStat_fccd12d8-bc08-4ec5-b6ee-f027a6ab55b5
+      hits_allowed: PickemStat_4dc8687c-fb40-486a-8be4-31c5a05dd3f1
+      bb_allowed: PickemStat_92390e5a-2c3e-4fc3-a31c-d71f51f97c5c
     snapshot_output_dir: data/lines
     snapshot_filename_template: "{stat}_{date}.csv"
     orchestration_defaults:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,32 @@ Sports:
 - NFL: `src/nfl/*`
 - NHL: `src/nhl/*`
 
+## MLB Live Underdog Shadow Workflow
+
+The live Underdog path is an auxiliary orchestration layer that sits on top of
+the existing stat-specific MLB pitcher-prop pipelines. It is shadow/manual only
+and does not change the canonical `pipeline/main.py` runtime entrypoint.
+
+Target module responsibilities:
+- `src/mlb/data/underdog.py`: fetch and normalize Underdog `PickemStat_*`
+  payloads into stat-specific live line frames.
+- `src/mlb/pitcher_props/live_lines.py`: map live rows into dated snapshot files
+  that satisfy the stat-specific `lines_path` loaders.
+- `src/mlb/pitcher_props/slate.py`: run the supported stat pipelines, combine
+  successful outputs into one candidate frame, and record skipped or failed
+  stats in the run summary.
+- `src/mlb/slips.py`: consume the generic candidate-leg schema, allow
+  same-pitcher stacks, and enforce the hard `2-player / 2-team` slip rule.
+- `scripts/build_mlb_live_betslips.py`: write JSON slip artifacts for manual
+  review only.
+
+The orchestration should remain thin:
+1. fetch live stat lines
+2. persist optional dated snapshots
+3. score the available props with the existing MLB stat pipelines
+4. normalize scored rows into a shared candidate-leg table
+5. generate JSON slips that satisfy the validity rules
+
 ## NHL Runtime Topology
 
 Data layer:
@@ -82,6 +108,8 @@ Orchestration:
 
 - Existing output schema columns for MLB/NFL are backward-compatible commitments.
 - NHL output columns are contract-stable for current `shots_on_goal` pipeline.
+- MLB live Underdog runs are shadow/manual and must not auto-submit or mutate
+  downstream account workflows.
 - Model artifact compatibility is schema-hash based where implemented (NHL today).
 - Tests are offline by default; network behavior must be optional and guarded.
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -52,6 +52,24 @@ Common optional keys (defaults/fallbacks exist in code):
 - `fallback_std`
 - `live_features.*` (where applicable)
 
+## MLB Live Underdog Shadow-Run Contract
+
+This section describes an auxiliary workflow contract, not loader-enforced
+runtime-critical keys.
+
+- `mlb.live_underdog.stat_ids.<stat>`: configured `PickemStat_*` id for each
+  supported MLB stat.
+- `mlb.live_underdog.snapshot_output_dir`: optional dated snapshot directory for
+  live line exports.
+- `mlb.live_underdog.snapshot_filename_template`: optional filename template for
+  dated snapshots.
+- `mlb.live_underdog.orchestration_defaults.*`: shared shadow-run defaults for
+  mixed-stat slip generation, including same-pitcher stacking enabled by
+  default, JSON-only output, and the hard `2-player / 2-team` minimum.
+
+The live workflow may materialize dated line snapshots into the stat-specific
+`lines_path` inputs consumed by the existing MLB pitcher-prop pipelines.
+
 ### NFL (`nfl.pass_attempts`)
 Required:
 - `training_years` (non-empty `list[int]`)
@@ -97,6 +115,30 @@ mlb:
     pitch_data_path: tests/testdata/pitches.csv
     model_path: /tmp/mlb_strikeouts_model.joblib
     lines_path: tests/testdata/lines_with_odds.csv
+```
+
+### MLB live Underdog shadow workflow fragment
+
+This fragment is intended to be merged into a complete sectioned MLB config
+that already includes `pipeline.sport`, `pipeline.stat`, and the active
+`mlb.{stat}` runtime section.
+
+```yaml
+mlb:
+  live_underdog:
+    stat_ids:
+      strikeouts: PickemStat_de868934-c920-405c-b827-693c15aa47a1
+      outs_recorded: PickemStat_...
+      earned_runs: PickemStat_...
+      hits_allowed: PickemStat_...
+      bb_allowed: PickemStat_...
+    snapshot_output_dir: data/lines
+    snapshot_filename_template: "{stat}_{date}.csv"
+    orchestration_defaults:
+      same_pitcher_stacking: true
+      min_players_per_slip: 2
+      min_teams_per_slip: 2
+      json_only: true
 ```
 
 ### NFL

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -58,6 +58,35 @@ Shared naming is sport-neutral (`line`, `entity_id`) with caller-specified colum
 - Walks allowed: `predicted_bb_allowed`, `bb_line`
 - Mode metadata where applicable: `run_mode`, `lines_status`
 
+### MLB live Underdog shadow contract
+Live Underdog ingestion supports the full modeled MLB pitcher-prop slate:
+`strikeouts`, `outs_recorded`, `earned_runs`, `hits_allowed`, and `bb_allowed`.
+
+Normalized candidate legs share a stat-neutral schema built from live prop rows:
+- `player_id`
+- `player_name`
+- `team`
+- `opponent`
+- `game_id`
+- `scheduled_at`
+- `stat_id`
+- `line`
+- `side`
+- `prob_over`
+- `prob_under`
+- `ev_over`
+- `ev_under`
+- payout fields
+- model provenance / run metadata
+
+Slip contracts for the shadow workflow are stricter than the leg schema:
+- Same-pitcher stacking is allowed.
+- Every emitted slip must contain at least 2 distinct players.
+- Every emitted slip must contain at least 2 distinct teams.
+- Output artifacts are JSON-only and intended for manual review.
+- Dated line snapshots are operational inputs, not a change to the scoring
+  contract.
+
 ### NFL fields
 - `predicted_pass_attempts`
 - `attempts_line`

--- a/docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-design.md
+++ b/docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-design.md
@@ -1,6 +1,6 @@
 # MLB Underdog Lines and Betslips Design
 
-Status: Planned
+Status: Implemented
 
 Date: 2026-03-25
 

--- a/docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-implementation-plan.md
+++ b/docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-implementation-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-Status: Planned
+Status: Implemented
 
 Date: 2026-03-25
 
@@ -84,7 +84,7 @@ Rules for every slice:
 ### Task 1: Lock the provider contract and planning docs
 
 **Files:**
-- Review: `docs/plans/planned/2026-03-25-mlb-underdog-lines-betslips-design.md`
+- Review: `docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-design.md`
 - Modify: `docs/config-schema.md`
 - Modify: `docs/contracts.md`
 - Modify: `docs/architecture.md`

--- a/docs/plans/plan-doneness-audit-2026-02-08.md
+++ b/docs/plans/plan-doneness-audit-2026-02-08.md
@@ -5,6 +5,8 @@ Status: Audit Report (Not a Plan Spec)
 Note: This file is an audit artifact summarizing plan-completion evidence. It is not an executable plan specification.
 
 ## Scope audited
+- `docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-design.md`
+- `docs/plans/implemented/2026-03-25-mlb-underdog-lines-betslips-implementation-plan.md`
 - `docs/plans/implemented/mlb-multi-stat-expansion-plan.md`
 - `docs/plans/implemented/mlb-multistat-tournament-plan.md`
 - `docs/plans/planned/mlb-pybaseball-live-features-plan.md`
@@ -15,6 +17,8 @@ Note: This file is an audit artifact summarizing plan-completion evidence. It is
 - `docs/plans/planned/nhl-pr4-nfl-decoupling-cleanup-plan.md`
 
 ## Summary verdict
+- `2026-03-25-mlb-underdog-lines-betslips-design.md`: **Implemented**.
+- `2026-03-25-mlb-underdog-lines-betslips-implementation-plan.md`: **Implemented**.
 - `mlb-multi-stat-expansion-plan.md`: **Implemented**.
 - `mlb-multistat-tournament-plan.md`: **Implemented** (acceptance criteria met by code + tests).
 - `mlb-pybaseball-live-features-plan.md`: **Partially implemented** (engineering scope implemented; strict MAE+ gate still not met).
@@ -25,6 +29,32 @@ Note: This file is an audit artifact summarizing plan-completion evidence. It is
 - `nhl-pr4-nfl-decoupling-cleanup-plan.md`: **Planned (Approved)** (decision-complete execution plan approved; not yet implemented).
 
 ## Evidence
+
+### 0) MLB Underdog Lines and Betslips Design + Implementation Plan
+Status: **Implemented**
+
+Implemented evidence:
+- Live Underdog MLB ingestion helpers added in `src/mlb/data/underdog.py`.
+- Multi-stat live line normalization and snapshot writing added in
+  `src/mlb/pitcher_props/live_lines.py` and `src/mlb/data/load_props.py`.
+- Unified multi-stat slate orchestration added in `src/mlb/pitcher_props/slate.py`.
+- Mixed-stat and same-pitcher MLB slip generation supported in `src/mlb/slips.py`.
+- Shadow-run CLI added in `scripts/build_mlb_live_betslips.py`.
+- Config contract and defaults wired in `src/core/config.py` and `config/mlb.yaml`.
+- Canonical docs updated in `README.md`, `docs/architecture.md`,
+  `docs/contracts.md`, and `docs/config-schema.md`.
+- Offline validation coverage added in:
+  - `tests/test_mlb_underdog_lines.py`
+  - `tests/test_mlb_pitcher_prop_live_lines.py`
+  - `tests/test_mlb_pitcher_prop_slate.py`
+  - `tests/test_mlb_mixed_prop_slips.py`
+  - `tests/test_build_mlb_live_betslips.py`
+  - `tests/test_core_config.py`
+
+Validation evidence:
+- Targeted Task 8 tests pass.
+- `.venv/bin/ruff check .` passes.
+- `.venv/bin/pytest -q` passes.
 
 ### 1) MLB Multi-Stat Expansion Plan
 Status: **Implemented**

--- a/docs/plans/planned/2026-03-25-mlb-underdog-lines-betslips-design.md
+++ b/docs/plans/planned/2026-03-25-mlb-underdog-lines-betslips-design.md
@@ -1,0 +1,127 @@
+# MLB Underdog Lines and Betslips Design
+
+Status: Planned
+
+Date: 2026-03-25
+
+## Goal
+Add a shadow-mode MLB workflow that fetches live Underdog pitcher-prop lines for
+ all supported modeled stats, scores the available props with existing MLB
+ pitcher-prop pipelines, and generates JSON betslips from the combined candidate
+ pool.
+
+## Scope
+### In scope
+- Live Underdog ingestion for all currently modeled MLB pitcher props:
+  - `strikeouts`
+  - `outs_recorded`
+  - `earned_runs`
+  - `hits_allowed`
+  - `bb_allowed`
+- Mixed-stat slip generation across the full MLB pitcher-prop slate.
+- Same-pitcher stacking by default.
+- JSON slip outputs only.
+- Shadow/manual workflow only.
+
+### Out of scope
+- Auto-submit or account automation.
+- Batter props.
+- New modeled MLB stats.
+- Correlation modeling beyond explicit slip validity rules.
+
+## Current Repo State
+- NFL already has a working Underdog ingestion helper in
+  `src/nfl/data/underdog.py`.
+- MLB pitcher-prop scoring already exists per stat via
+  `pipeline/main.py` -> `src/pipeline/engine.py` ->
+  `src/mlb/pitcher_props/pipeline.py`.
+- MLB slip generation exists, but it is strikeouts-specific in
+  `src/mlb/slips.py` and the wrapper script `scripts/build_betslips.py`.
+- MLB currently expects prepared `data/lines/*.csv` inputs and does not yet have
+  a live Underdog line importer.
+
+## Design Decisions
+### 1) Use a unified MLB slate orchestrator over existing stat pipelines
+Do not build a brand-new MLB modeling pipeline. Reuse the existing stat-specific
+ MLB pitcher-prop pipelines as scoring engines and add a thin orchestration layer
+ above them.
+
+### 2) Fetch all supported MLB pitcher props from Underdog
+Add an MLB Underdog ingestion module that:
+- discovers or uses configured `PickemStat_*` ids per stat,
+- fetches raw payloads from the same Underdog API shape used by NFL,
+- normalizes the live lines into stat-specific frames compatible with the
+  current MLB line loaders,
+- writes dated line snapshots for shadow/manual runs.
+
+### 3) Normalize scored props into a common candidate-leg schema
+Each scored prop row should be converted into a common schema that includes:
+- player identity,
+- team,
+- opponent,
+- scheduled date/time if available,
+- stat id,
+- line value,
+- side (`over`/`under`),
+- probabilities,
+- EV,
+- payout fields,
+- model output metadata.
+
+This removes the strikeouts-specific assumptions from slip construction.
+
+### 4) Allow same-pitcher stacking by default
+Underdog now supports stacking one player's stats, so same-pitcher legs are
+ valid candidates by default.
+
+### 5) Enforce slip validity with a 2-player / 2-team minimum
+Every emitted slip must include:
+- at least 2 distinct players,
+- at least 2 distinct teams.
+
+This is a hard rule even when same-pitcher stacks are present.
+
+### 6) Keep the first version shadow-only
+The first version should:
+- fetch live lines,
+- score available props,
+- generate JSON slips,
+- write artifacts for review.
+
+It should not place picks or automate any downstream submission flow.
+
+## Data Flow
+1. Fetch live Underdog MLB pitcher-prop payloads for all configured stats.
+2. Normalize the payloads into stat-specific live line frames.
+3. Persist dated line snapshots under `data/lines/`.
+4. Run the existing MLB stat pipelines against those line files.
+5. Normalize all scored rows into a combined candidate-leg table.
+6. Build mixed slips from that table under the configured slip rules.
+7. Write JSON slip artifacts and a run summary.
+
+## Error Handling
+- If a stat id is missing or Underdog returns no lines for that stat, skip that
+  stat and continue.
+- If a stat payload shape is invalid, fail that stat loudly and continue with the
+  others.
+- If a stat pipeline fails, record it in the run summary and continue unless all
+  stats fail.
+- If the candidate pool cannot form valid slips under the 2-player / 2-team
+  rule, emit zero slips with a clear explanation.
+- Keep tests offline by mocking Underdog payloads and pipeline outputs.
+
+## Config Direction
+The implementation should keep unstable provider ids and operator choices out of
+deep code paths. Underdog stat ids and orchestration defaults should live in
+config and/or top-level constants that are easy to update.
+
+## Acceptance Criteria
+- The repo can fetch MLB live Underdog pitcher-prop lines for all supported
+  modeled stats.
+- The repo can score all available props for a target slate with existing MLB
+  models.
+- The repo can generate JSON slips containing mixed stats and same-pitcher
+  stacks.
+- No emitted slip violates the 2-player / 2-team minimum rule.
+- Offline tests cover ingestion normalization, candidate-leg normalization, and
+  slip-validation behavior.

--- a/docs/plans/planned/2026-03-25-mlb-underdog-lines-betslips-implementation-plan.md
+++ b/docs/plans/planned/2026-03-25-mlb-underdog-lines-betslips-implementation-plan.md
@@ -1,0 +1,417 @@
+# MLB Underdog Lines and Betslips Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a shadow-mode MLB workflow that fetches live Underdog pitcher-prop lines for all supported modeled stats, scores the available props, and generates JSON betslips with mixed-stat and same-pitcher support.
+
+**Architecture:** Reuse the existing MLB pitcher-prop pipelines as the scoring engines. Add a shared MLB Underdog ingestion layer plus a thin orchestration layer that fetches live lines, writes dated snapshots, normalizes scored outputs into a common candidate-leg schema, and generates slips with explicit validity rules.
+
+**Tech Stack:** Python 3.11, pandas, repo-local CLI scripts, existing MLB pitcher-prop pipeline modules, existing Underdog NFL API pattern, pytest, ruff.
+
+---
+
+Status: Planned
+
+Date: 2026-03-25
+
+## Stacked Diff Strategy
+Execute this plan as a series of small reviewable branches/PRs, not one large
+change. Target roughly 150-400 net lines per slice when possible, and avoid
+mixing ingestion, orchestration, slip logic, and docs in the same review unless
+the dependency is trivial.
+
+Recommended stack:
+
+1. `mlb-ud-lines-pr1-contracts`
+- Scope:
+  - config/docs contract only
+  - no live network behavior
+- Expected review surface:
+  - docs and config-schema updates
+  - any minimal config validation tests
+
+2. `mlb-ud-lines-pr2-ingestion`
+- Scope:
+  - `src/mlb/data/underdog.py`
+  - payload parsing/normalization tests
+- Exclude:
+  - no pipeline orchestration
+  - no slip-builder changes
+
+3. `mlb-ud-lines-pr3-line-snapshots`
+- Scope:
+  - stat-specific line normalization
+  - dated snapshot writing helpers
+- Exclude:
+  - no combined slate scoring
+  - no betslip generation changes
+
+4. `mlb-ud-lines-pr4-slate-orchestration`
+- Scope:
+  - unified multi-stat MLB slate scoring orchestration
+  - run-summary behavior for skipped/failed stats
+- Exclude:
+  - no slip-builder generalization yet
+
+5. `mlb-ud-lines-pr5-mixed-slips`
+- Scope:
+  - generic candidate-leg schema
+  - mixed-stat slip generation
+  - same-pitcher stacking support
+  - hard 2-player / 2-team validation rule
+
+6. `mlb-ud-lines-pr6-live-cli`
+- Scope:
+  - live CLI wrapper
+  - JSON artifact writing
+  - README updates for operator workflow
+
+7. `mlb-ud-lines-pr7-validation-and-polish`
+- Scope:
+  - final config wiring
+  - targeted cleanup
+  - validation evidence
+- Only include code if discovered during validation. Do not save unrelated
+  refactors for this PR.
+
+Rules for every slice:
+- Each PR must be independently reviewable against its parent branch.
+- Each PR must include the tests that justify its behavior.
+- Do not defer test coverage for behavior introduced in the slice.
+- Keep docs aligned with the code introduced in that slice only.
+- If a slice starts growing too large, split it again before implementation.
+
+### Task 1: Lock the provider contract and planning docs
+
+**Files:**
+- Review: `docs/plans/planned/2026-03-25-mlb-underdog-lines-betslips-design.md`
+- Modify: `docs/config-schema.md`
+- Modify: `docs/contracts.md`
+- Modify: `docs/architecture.md`
+
+**Step 1: Write the failing test**
+
+Add or update a config-contract test that fails until MLB live Underdog config
+keys for multi-stat ingestion are recognized.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q <targeted test>`
+
+Expected: config/schema assertion fails on new MLB live-ingestion keys.
+
+**Step 3: Write minimal implementation**
+
+Document the new config surface for:
+- MLB Underdog stat ids by stat,
+- optional output paths for dated line snapshots,
+- unified betslip orchestration defaults.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q <targeted test>`
+
+Expected: config/schema test passes.
+
+**Step 5: Commit**
+
+```bash
+git add docs/config-schema.md docs/contracts.md docs/architecture.md
+git commit -m "docs: define MLB Underdog lines and betslip contract"
+```
+
+### Task 2: Add MLB Underdog line ingestion primitives
+
+**Files:**
+- Create: `src/mlb/data/underdog.py`
+- Modify: `src/mlb/data/__init__.py`
+- Test: `tests/test_mlb_underdog_lines.py`
+
+**Step 1: Write the failing test**
+
+Add fixture-based tests that:
+- parse a mocked Underdog payload for one MLB stat,
+- normalize player, game, odds, and line metadata,
+- return an empty frame when no matching lines exist.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q tests/test_mlb_underdog_lines.py`
+
+Expected: import/helper functions do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Mirror the NFL Underdog helper pattern, but normalize MLB pitcher-prop rows into
+a reusable schema that supports stat-specific line columns and shared odds
+fields.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q tests/test_mlb_underdog_lines.py`
+
+Expected: payload parsing tests pass offline.
+
+**Step 5: Commit**
+
+```bash
+git add src/mlb/data/underdog.py src/mlb/data/__init__.py tests/test_mlb_underdog_lines.py
+git commit -m "feat: add MLB Underdog line ingestion helpers"
+```
+
+### Task 3: Support multi-stat live line normalization and snapshot writing
+
+**Files:**
+- Modify: `src/mlb/data/load_props.py`
+- Create: `src/mlb/pitcher_props/live_lines.py`
+- Test: `tests/test_mlb_pitcher_prop_live_lines.py`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+- map unified live rows into per-stat line files,
+- preserve required columns for each MLB stat,
+- write dated snapshot outputs deterministically.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q tests/test_mlb_pitcher_prop_live_lines.py`
+
+Expected: normalizer/snapshot helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create helpers that transform fetched Underdog rows into the stat-specific CSV
+shape expected by `load_pitcher_prop_lines` and persist dated snapshots for a
+target slate.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q tests/test_mlb_pitcher_prop_live_lines.py`
+
+Expected: normalized live-line tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/mlb/data/load_props.py src/mlb/pitcher_props/live_lines.py tests/test_mlb_pitcher_prop_live_lines.py
+git commit -m "feat: normalize live MLB pitcher-prop line snapshots"
+```
+
+### Task 4: Add unified MLB slate scoring orchestration
+
+**Files:**
+- Create: `src/mlb/pitcher_props/slate.py`
+- Modify: `src/mlb/pitcher_props/__init__.py`
+- Test: `tests/test_mlb_pitcher_prop_slate.py`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+- run multiple mocked MLB stat scorers,
+- skip unavailable stats cleanly,
+- produce one combined scored candidate frame.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q tests/test_mlb_pitcher_prop_slate.py`
+
+Expected: slate orchestration module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Build a thin orchestrator that:
+- fetches or accepts live lines per stat,
+- invokes the existing MLB pitcher-prop pipelines,
+- combines successful stat outputs into one frame,
+- records skipped/failed stats for run reporting.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q tests/test_mlb_pitcher_prop_slate.py`
+
+Expected: multi-stat orchestration tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/mlb/pitcher_props/slate.py src/mlb/pitcher_props/__init__.py tests/test_mlb_pitcher_prop_slate.py
+git commit -m "feat: add unified MLB pitcher-prop slate scoring"
+```
+
+### Task 5: Generalize candidate-leg normalization for mixed MLB slips
+
+**Files:**
+- Modify: `src/mlb/slips.py`
+- Test: `tests/test_slips.py`
+- Create: `tests/test_mlb_mixed_prop_slips.py`
+
+**Step 1: Write the failing test**
+
+Add tests that:
+- generate slips from mixed MLB stat rows,
+- allow same-pitcher stacks,
+- reject slips that do not include at least 2 distinct players and 2 distinct
+  teams.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q tests/test_slips.py tests/test_mlb_mixed_prop_slips.py`
+
+Expected: current strikeouts-specific slip builder cannot satisfy the mixed-stat
+schema or validity rules.
+
+**Step 3: Write minimal implementation**
+
+Refactor the MLB slip builder to consume a common candidate-leg schema with
+generic stat fields instead of strikeouts-only columns. Add the 2-player / 2-team
+ validator as a hard filter during slip generation.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q tests/test_slips.py tests/test_mlb_mixed_prop_slips.py`
+
+Expected: slip tests pass with same-pitcher stacking and rule enforcement.
+
+**Step 5: Commit**
+
+```bash
+git add src/mlb/slips.py tests/test_slips.py tests/test_mlb_mixed_prop_slips.py
+git commit -m "feat: support mixed MLB pitcher-prop slips"
+```
+
+### Task 6: Add a CLI for live fetch -> score -> JSON slips
+
+**Files:**
+- Modify: `scripts/build_betslips.py`
+- Create: `scripts/build_mlb_live_betslips.py`
+- Test: `tests/test_build_mlb_live_betslips.py`
+- Modify: `README.md`
+
+**Step 1: Write the failing test**
+
+Add a CLI-level test that:
+- mocks live Underdog payload fetches,
+- mocks stat scoring outputs,
+- verifies JSON slips are written for a target slate.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q tests/test_build_mlb_live_betslips.py`
+
+Expected: live orchestration CLI does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a dedicated CLI entrypoint for MLB live shadow runs that:
+- fetches lines,
+- writes dated snapshots,
+- scores all available modeled pitcher props,
+- emits JSON slips and a concise run summary.
+
+Keep the older `scripts/build_betslips.py` compatible where practical, but do not
+force it to own the full live multi-stat workflow if a separate script is
+cleaner.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q tests/test_build_mlb_live_betslips.py`
+
+Expected: live MLB betslip CLI tests pass offline.
+
+**Step 5: Commit**
+
+```bash
+git add scripts/build_betslips.py scripts/build_mlb_live_betslips.py tests/test_build_mlb_live_betslips.py README.md
+git commit -m "feat: add MLB live betslip shadow-run CLI"
+```
+
+### Task 7: Wire config defaults and stat-id lookup behavior
+
+**Files:**
+- Modify: `config/mlb.yaml`
+- Modify: `src/core/config.py`
+- Test: `tests/test_core_config.py`
+
+**Step 1: Write the failing test**
+
+Add config-loading tests for the new MLB live-line config surface and fallback
+behavior when some stat ids are absent.
+
+**Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest -q tests/test_core_config.py`
+
+Expected: config validation does not recognize the new keys or defaults.
+
+**Step 3: Write minimal implementation**
+
+Add config support for MLB live Underdog stat-id mappings and any required
+orchestration defaults without breaking current stat-specific MLB configs.
+
+**Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest -q tests/test_core_config.py`
+
+Expected: new config tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add config/mlb.yaml src/core/config.py tests/test_core_config.py
+git commit -m "feat: add MLB live lines config wiring"
+```
+
+### Task 8: Run targeted and full validation
+
+**Files:**
+- Review: `tests/test_mlb_underdog_lines.py`
+- Review: `tests/test_mlb_pitcher_prop_live_lines.py`
+- Review: `tests/test_mlb_pitcher_prop_slate.py`
+- Review: `tests/test_slips.py`
+- Review: `tests/test_mlb_mixed_prop_slips.py`
+- Review: `tests/test_build_mlb_live_betslips.py`
+
+**Step 1: Run targeted tests**
+
+Run:
+- `.venv/bin/pytest -q tests/test_mlb_underdog_lines.py`
+- `.venv/bin/pytest -q tests/test_mlb_pitcher_prop_live_lines.py`
+- `.venv/bin/pytest -q tests/test_mlb_pitcher_prop_slate.py`
+- `.venv/bin/pytest -q tests/test_slips.py tests/test_mlb_mixed_prop_slips.py`
+- `.venv/bin/pytest -q tests/test_build_mlb_live_betslips.py`
+
+Expected: all new/modified behavior tests pass.
+
+**Step 2: Run repo validation**
+
+Run:
+- `.venv/bin/ruff check .`
+- `.venv/bin/pytest -q`
+
+Expected: lint and full offline suite pass.
+
+**Step 3: Manual smoke check**
+
+Run a shadow/manual MLB live workflow against a temp output path and capture:
+- which stats returned live lines,
+- how many candidate legs were scored,
+- how many slips were emitted,
+- whether every emitted slip satisfied the 2-player / 2-team rule.
+
+**Step 4: Commit**
+
+```bash
+git add README.md docs/config-schema.md docs/contracts.md docs/architecture.md config/mlb.yaml src tests scripts
+git commit -m "chore: validate MLB live Underdog betslip workflow"
+```
+
+## Notes
+- Keep all tests offline by using mocked Underdog payloads and mocked or fixture
+  MLB pipeline outputs.
+- Do not auto-submit slips or add operator-account logic in this plan.
+- Treat live Underdog stat ids as updateable config/constants, not deep internal
+  invariants.
+- Preserve existing sportsbook pipeline entrypoints and output schema where
+  possible.
+- Prefer one commit per task and one PR per stacked-diff slice.

--- a/docs/plans/planned/2026-05-14-mlb-proof-run-hardening-plan.md
+++ b/docs/plans/planned/2026-05-14-mlb-proof-run-hardening-plan.md
@@ -1,0 +1,247 @@
+# MLB Proof-Run Hardening Plan
+
+Status: Planned
+
+Date: 2026-05-14
+
+## Goal
+Harden the existing MLB live shadow workflow so it can explicitly distinguish a
+valid proof run, a healthy no-play slate, a debug-only subset run, and a failed
+run caused by runtime or sanity issues.
+
+## Why this exists
+The repo already supports MLB live Underdog shadow runs, but the current CLI has
+two operator gaps:
+
+1. It requires manual `--stat-id` input even though config already stores live
+   stat ids.
+2. It writes runtime summaries without an explicit verdict about whether the run
+   was trustworthy, degraded, or suitable only for debugging.
+
+This plan adds operator-facing correctness gates without mixing in model-refresh
+or retraining work.
+
+## Scope
+### In scope
+- Extend `scripts/build_mlb_live_betslips.py`; do not create a second command.
+- Add explicit run modes:
+  - `proof` (default)
+  - `debug`
+- Default live stat-id sourcing from `mlb.live_underdog.stat_ids` in
+  `config/mlb.yaml`.
+- Keep CLI `--stat-id` values as overrides.
+- Require full five-market stat-id coverage in `proof` mode.
+- Allow subset stat-id overrides in `debug` mode.
+- Add explicit verdict/output semantics:
+  - `passed`
+  - `failed`
+  - `no_play_slate`
+- Add structured failure reasons for failed proof runs:
+  - `missing_required_stat_ids`
+  - `runtime_failure`
+  - `stat_mix_gate_failed`
+  - `confidence_gate_failed`
+- Add proof-run evidence to the summary JSON and CLI output.
+- Add hard sanity-gate enforcement in `proof` mode and warning-only reporting in
+  `debug` mode.
+
+### Out of scope
+- Data refresh or retraining for current-season MLB models.
+- Historical calibration of gate thresholds.
+- Auto-submission or account automation.
+- New MLB prop markets.
+
+## Domain decisions locked
+- Proof-run hardening and freshness/retraining are separate plans.
+- A proof run validates workflow correctness; it does not imply betting
+  readiness.
+- A no-play slate is a successful proof-run outcome when the workflow and
+  sanity checks are healthy.
+- Proof mode requires all currently supported MLB pitcher-prop markets.
+- Debug mode exists for subset runs and targeted provider/model investigation.
+- Proof and debug runs share one summary schema with an explicit `mode` field.
+
+## Initial sanity gates
+### Stat-Mix Gate
+- Inspect the slip-eligible pool, not the full scored slate.
+- Fail `proof` mode when any one `stat_id` exceeds 70% of the slip-eligible
+  pool.
+- Report as warning only in `debug` mode.
+
+### Confidence Gate
+- Inspect the slip-eligible pool, not the full scored slate.
+- Fail `proof` mode when any slip-eligible leg has:
+  - `prob <= 0.20`
+  - `prob >= 0.80`
+  - `ev >= 0.35`
+- Report as warning only in `debug` mode.
+- Treat these thresholds as initial defaults pending later historical
+  calibration.
+
+## Summary contract changes
+Add explicit proof-run evidence to the existing summary shape:
+- `mode`
+- `outcome`
+- `failure_reasons`
+- `completed_stats`
+- `skipped_stats`
+- `failed_stats`
+- `combined_rows`
+- `slip_eligible_rows`
+- `stat_mix`
+- `probability_extremes`
+- `ev_extreme`
+- `slip_counts`
+
+The goal is that an operator can tell whether the run:
+- passed cleanly,
+- passed as a no-play slate,
+- failed due to missing required coverage,
+- failed due to runtime breakage,
+- failed due to sanity-gate triggers,
+
+without opening raw JSON slip artifacts by hand.
+
+## Execution slices
+### Slice 1: Config-backed stat-id defaults and run-mode contract
+Files:
+- Modify: `scripts/build_mlb_live_betslips.py`
+- Review: `src/core/config.py`
+- Test: `tests/test_build_mlb_live_betslips.py`
+- Modify: `README.md`
+
+Behavior:
+- Add explicit run mode argument with default `proof`.
+- Load stat ids from `mlb.live_underdog.stat_ids` when CLI overrides are not
+  supplied.
+- In `proof` mode, hard-fail before fetch/scoring if full supported-market
+  coverage is missing after config + CLI override resolution.
+- In `debug` mode, allow subset runs.
+
+Validation:
+- Proof mode uses config-backed stat ids by default.
+- CLI overrides replace configured ids for matching stats.
+- Proof mode rejects missing required stat ids.
+- Debug mode allows subset stat-id runs.
+
+### Slice 2: Proof-run verdict model and summary schema
+Files:
+- Modify: `scripts/build_mlb_live_betslips.py`
+- Test: `tests/test_build_mlb_live_betslips.py`
+
+Behavior:
+- Compute and persist one explicit summary schema for both proof and debug
+  modes.
+- Add:
+  - `mode`
+  - `outcome`
+  - `failure_reasons`
+  - proof-run evidence payload fields
+- Distinguish:
+  - `passed`
+  - `failed`
+  - `no_play_slate`
+
+Validation:
+- Summary JSON includes mode and explicit outcome.
+- Failed proof runs include structured failure reasons.
+- Healthy no-play outcomes are explicit and not mislabeled as failures.
+
+### Slice 3: Slip-eligible pool derivation for operator checks
+Files:
+- Modify: `scripts/build_mlb_live_betslips.py`
+- Review: `src/mlb/slips.py`
+- Test: `tests/test_build_mlb_live_betslips.py`
+
+Behavior:
+- Derive a stable slip-eligible pool from the same normalized candidate-leg
+  surface used for slip construction.
+- Record pool size and pool-level aggregates in proof-run evidence.
+
+Validation:
+- Proof-run evidence reports `slip_eligible_rows`.
+- Stat mix, probability bounds, and EV bounds are computed from that pool
+  rather than the full scored slate.
+
+### Slice 4: Stat-Mix Gate and Confidence Gate
+Files:
+- Modify: `scripts/build_mlb_live_betslips.py`
+- Test: `tests/test_build_mlb_live_betslips.py`
+- Consider: targeted new regression test file if CLI tests become too dense
+
+Behavior:
+- Implement hard proof-mode failures for:
+  - one-stat dominance above 70% of the slip-eligible pool
+  - probability bounds outside `[0.20, 0.80]`
+  - EV bound at or above `0.35`
+- In debug mode, keep the same evidence but downgrade gate trips to warnings.
+
+Validation:
+- Proof mode fails with `stat_mix_gate_failed` when dominance threshold is
+  exceeded.
+- Proof mode fails with `confidence_gate_failed` when probability/EV thresholds
+  are exceeded.
+- Debug mode preserves output artifacts and summary evidence while not claiming
+  proof-run validity.
+
+### Slice 5: Runtime vs no-play semantics
+Files:
+- Modify: `scripts/build_mlb_live_betslips.py`
+- Test: `tests/test_build_mlb_live_betslips.py`
+
+Behavior:
+- Treat partial stat failures as acceptable degradation unless they prevent:
+  - a non-empty slip-eligible pool, and
+  - at least one valid slip artifact
+- Distinguish between:
+  - `runtime_failure`
+  - `no_play_slate`
+
+Validation:
+- Runtime failures are emitted only when the workflow cannot produce a usable
+  actionable surface.
+- Healthy abstention is emitted as `no_play_slate`.
+
+### Slice 6: Docs and operator usage
+Files:
+- Modify: `README.md`
+- Modify: `docs/config-schema.md`
+- Modify: `docs/contracts.md`
+- Modify: `docs/architecture.md`
+
+Behavior:
+- Document proof/debug modes.
+- Document config-backed stat-id defaults and CLI override behavior.
+- Document summary/verdict semantics and initial sanity gates.
+
+## TDD guidance
+For each slice:
+1. Add or update failing targeted tests first.
+2. Implement the smallest change that passes.
+3. Re-run targeted tests.
+4. Re-run repo-level verification at the end.
+
+## Acceptance criteria
+- The existing MLB live shadow CLI defaults to `proof` mode.
+- Proof mode loads MLB live stat ids from config by default.
+- Proof mode hard-fails when full supported-market stat-id coverage is missing.
+- Debug mode allows subset stat-id runs.
+- Proof and debug runs share one summary schema with an explicit `mode`.
+- Proof mode emits explicit outcomes:
+  - `passed`
+  - `failed`
+  - `no_play_slate`
+- Failed proof runs emit structured failure reasons from the agreed initial set.
+- Proof-mode summary evidence includes slip-eligible pool shape plus stat-mix,
+  probability, and EV diagnostics.
+- Stat-mix and confidence gates hard-fail proof mode and warn in debug mode.
+- Healthy abstention is surfaced explicitly as `no_play_slate`.
+
+## Final validation
+Run at minimum:
+
+```bash
+.venv/bin/pytest -q tests/test_build_mlb_live_betslips.py
+.venv/bin/pytest -q
+.venv/bin/ruff check .
+```

--- a/scripts/build_betslips.py
+++ b/scripts/build_betslips.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
+# ruff: noqa: I001
 """Generate conservative and full-send bet slips from the MLB pipeline output."""
 
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -25,6 +25,7 @@ def _derive_target_date(df: pd.DataFrame) -> datetime:
 
 
 def main() -> None:
+    from scripts.build_mlb_live_betslips import write_slip_artifacts
     from src.mlb.pipeline import run
     from src.mlb.slips import SlipBuilderConfig, build_slip_sets
 
@@ -86,17 +87,20 @@ def main() -> None:
     output_dir = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    for tag, slips in slip_sets.items():
-        filename = f"{args.prefix}_{target_date}_{tag}.json"
-        path = output_dir / filename
-        payload = {
+    paths = write_slip_artifacts(
+        output_dir=output_dir,
+        prefix=args.prefix,
+        target_date=target_date,
+        slip_sets=slip_sets,
+        payload_common={
             "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
             "config_path": args.config,
             "retrained": args.retrain,
-            "slips": slips,
-        }
-        path.write_text(json.dumps(payload, indent=2))
-        print(f"Wrote {len(slips)} {tag} slips to {path}")
+        },
+    )
+
+    for tag, slips in slip_sets.items():
+        print(f"Wrote {len(slips)} {tag} slips to {paths[tag]}")
 
 
 if __name__ == "__main__":

--- a/scripts/build_mlb_live_betslips.py
+++ b/scripts/build_mlb_live_betslips.py
@@ -28,6 +28,7 @@ from src.mlb.data.underdog import import_ud_mlb_lines
 from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS
 from src.mlb.pitcher_props.live_lines import write_live_pitcher_prop_snapshot
 from src.mlb.pitcher_props.slate import run_mlb_pitcher_prop_slate
+from src.mlb.slip_report import render_slip_report
 from src.mlb.slips import SlipBuilderConfig, build_slip_sets, prepare_long_df
 
 DEFAULT_CONFIG_PATH = "config/mlb.yaml"
@@ -209,119 +210,6 @@ def write_slip_artifacts(
         path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
         paths[tag] = path
     return paths
-
-
-def _humanize_stat(stat_id: object) -> str:
-    """Return a human-readable stat label."""
-
-    stat_text = str(stat_id or "").strip()
-    if not stat_text:
-        return "stat"
-    return stat_text.replace("_", " ")
-
-
-def _format_decimal(value: object, digits: int = 2) -> str:
-    """Return a compact decimal string for numeric values."""
-
-    numeric = pd.to_numeric([value], errors="coerce")[0]
-    if pd.isna(numeric):
-        return "n/a"
-    text = f"{float(numeric):.{digits}f}"
-    return text.rstrip("0").rstrip(".")
-
-
-def _format_percent(value: object) -> str:
-    """Return a percentage string for a probability value."""
-
-    numeric = pd.to_numeric([value], errors="coerce")[0]
-    if pd.isna(numeric):
-        return "n/a"
-    return f"{float(numeric) * 100:.1f}%"
-
-
-def _format_signed_decimal(value: object, digits: int = 2) -> str:
-    """Return a signed decimal string for numeric values."""
-
-    numeric = pd.to_numeric([value], errors="coerce")[0]
-    if pd.isna(numeric):
-        return "n/a"
-    return f"{float(numeric):+.{digits}f}"
-
-
-def _predicted_value_for_leg(leg: dict[str, Any]) -> object:
-    """Return the best available model prediction for a slip leg."""
-
-    prediction_column = (
-        f"predicted_{str(leg.get('stat_id', '')).strip().lower()}" if leg else ""
-    )
-    if prediction_column and prediction_column in leg:
-        return leg.get(prediction_column)
-    return leg.get("predicted_value")
-
-
-def _format_leg_line(leg: dict[str, Any], index: int) -> str:
-    """Return a single human-readable line for a slip leg."""
-
-    player = str(leg.get("player") or leg.get("pitcher_name") or "Unknown player")
-    team = str(leg.get("team") or leg.get("pitcher_team") or "?")
-    opponent = str(leg.get("opponent") or leg.get("upcoming_opponent") or "?")
-    stat = _humanize_stat(leg.get("stat_id") or leg.get("market"))
-    play = str(leg.get("play") or "").lower()
-    line = _format_decimal(leg.get("line"), digits=1)
-    predicted = _format_decimal(_predicted_value_for_leg(leg))
-    prob = _format_percent(leg.get("prob"))
-    ev = _format_signed_decimal(leg.get("ev"))
-    return (
-        f"{index}. {player} ({team}) vs {opponent}: {stat} {play} {line} "
-        f"[model {predicted}, win {prob}, ev {ev}]"
-    )
-
-
-def render_slip_report(summary: dict[str, Any]) -> str:
-    """Return a human-readable report for generated slip artifacts."""
-
-    lines: list[str] = []
-    slip_files = summary.get("slip_files", {})
-    for tag in ("conservative", "fullsend"):
-        section_title = f"{tag.upper()} SLIPS"
-        lines.append(section_title)
-
-        path_text = slip_files.get(tag)
-        if not path_text:
-            lines.append("No artifact file recorded.")
-            lines.append("")
-            continue
-
-        path = Path(path_text)
-        if not path.exists():
-            lines.append(f"Missing artifact: {path}")
-            lines.append("")
-            continue
-
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        slips = payload.get("slips", [])
-        if not slips:
-            lines.append("None.")
-            lines.append("")
-            continue
-
-        for slip_index, slip in enumerate(slips, start=1):
-            lines.append(
-                " | ".join(
-                    [
-                        f"Slip {slip_index}",
-                        f"{int(slip.get('slip_size', len(slip.get('legs', []))))} legs",
-                        f"units {slip.get('units', 1)}",
-                        f"win {_format_percent(slip.get('p_win'))}",
-                        f"total ev {_format_signed_decimal(slip.get('total_ev'))}",
-                    ]
-                )
-            )
-            for leg_index, leg in enumerate(slip.get("legs", []), start=1):
-                lines.append(_format_leg_line(leg, leg_index))
-            lines.append("")
-
-    return "\n".join(lines).rstrip()
 
 
 def _target_date_from_frame(frame: pd.DataFrame) -> str:

--- a/scripts/build_mlb_live_betslips.py
+++ b/scripts/build_mlb_live_betslips.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python
+# ruff: noqa: I001, E402
+"""Run the MLB live Underdog shadow workflow and write JSON slip artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
+import sys
+from typing import Any
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.core.config import ConfigValidationError, load_pipeline_config
+from src.core.contracts import PipelineConfig
+from src.mlb.data.underdog import import_ud_mlb_lines
+from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS
+from src.mlb.pitcher_props.live_lines import write_live_pitcher_prop_snapshot
+from src.mlb.pitcher_props.slate import run_mlb_pitcher_prop_slate
+from src.mlb.slips import SlipBuilderConfig, build_slip_sets
+
+DEFAULT_CONFIG_PATH = "config/mlb.yaml"
+DEFAULT_OUTPUT_DIR = Path("betslips/mlb_live")
+DEFAULT_SNAPSHOT_DIR = Path("data/lines")
+DEFAULT_PREFIX = "mlb_live"
+
+
+def _parse_stat_id_pairs(stat_id_args: list[str]) -> dict[str, str]:
+    """Return a stat-id mapping parsed from ``STAT=PickemStat_*`` CLI args."""
+
+    mapping: dict[str, str] = {}
+    for raw in stat_id_args:
+        stat, separator, algolia_object_id = raw.partition("=")
+        if not separator:
+            raise ValueError(
+                "Invalid --stat-id value: expected STAT=PickemStat_<stat-id>."
+            )
+
+        stat_name = stat.strip().lower()
+        object_id = algolia_object_id.strip()
+        if not stat_name or not object_id:
+            raise ValueError(
+                "Invalid --stat-id value: expected STAT=PickemStat_<stat-id>."
+            )
+        if stat_name in mapping:
+            raise ValueError(f"Duplicate --stat-id entry for stat '{stat_name}'.")
+        mapping[stat_name] = object_id
+
+    return mapping
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the MLB live shadow workflow."""
+
+    parser = argparse.ArgumentParser(
+        description="Build MLB live Underdog shadow-run bet slips.",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the MLB config file used for stat pipelines.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where JSON slip artifacts are written.",
+    )
+    parser.add_argument(
+        "--snapshot-dir",
+        type=Path,
+        default=DEFAULT_SNAPSHOT_DIR,
+        help="Directory where dated live line snapshots are written.",
+    )
+    parser.add_argument(
+        "--prefix",
+        type=str,
+        default=DEFAULT_PREFIX,
+        help="Filename prefix for generated JSON artifacts.",
+    )
+    parser.add_argument(
+        "--retrain",
+        action="store_true",
+        help="Retrain each stat model before scoring the live slate.",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=12,
+        help="Number of top candidate legs to keep before slip generation.",
+    )
+    parser.add_argument(
+        "--conservative-count",
+        type=int,
+        default=3,
+        help="Maximum number of conservative slips to emit.",
+    )
+    parser.add_argument(
+        "--fullsend-count",
+        type=int,
+        default=5,
+        help="Maximum number of full-send slips to emit.",
+    )
+    parser.add_argument(
+        "--stat-id",
+        action="append",
+        dest="stat_ids",
+        default=[],
+        metavar="STAT=PickemStat_ID",
+        help="Map an MLB stat to its Underdog PickemStat id. Repeat per stat.",
+    )
+    return parser.parse_args()
+
+
+def write_slip_artifacts(
+    *,
+    output_dir: Path,
+    prefix: str,
+    target_date: str,
+    slip_sets: dict[str, list[dict[str, Any]]],
+    payload_common: dict[str, Any],
+) -> dict[str, Path]:
+    """Write JSON slip artifacts and return their paths."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, Path] = {}
+    for tag, slips in slip_sets.items():
+        path = output_dir / f"{prefix}_{target_date}_{tag}.json"
+        payload = {**payload_common, "slips": slips}
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        paths[tag] = path
+    return paths
+
+
+def _target_date_from_frame(frame: pd.DataFrame) -> str:
+    """Return the target slate date from scored or fetched rows."""
+
+    if "scheduled_at" in frame.columns:
+        dates = pd.to_datetime(frame["scheduled_at"], errors="coerce").dropna()
+        if not dates.empty:
+            return dates.min().date().isoformat()
+    if "game_date" in frame.columns:
+        dates = pd.to_datetime(frame["game_date"], errors="coerce").dropna()
+        if not dates.empty:
+            return dates.min().date().isoformat()
+    return datetime.utcnow().date().isoformat()
+
+
+def _is_expected_fetch_error(exc: Exception) -> bool:
+    """Return whether a live-line fetch failure should be recorded per stat."""
+
+    if isinstance(exc, json.JSONDecodeError):
+        return True
+    if isinstance(exc, RuntimeError):
+        return str(exc).startswith("Underdog API request failed with status ")
+    return isinstance(exc, OSError)
+
+
+def run_live_shadow_workflow(args: argparse.Namespace) -> dict[str, Any]:
+    """Fetch live lines, score the slate, and emit JSON artifacts."""
+
+    stat_ids = _parse_stat_id_pairs(list(args.stat_ids))
+    if not stat_ids:
+        raise ValueError("At least one --stat-id mapping is required.")
+    missing_stats = sorted(stat for stat in stat_ids if stat not in STAT_DESCRIPTORS)
+    if missing_stats:
+        supported = ", ".join(sorted(STAT_DESCRIPTORS))
+        raise ValueError(
+            "Unsupported MLB stat-id mapping(s): "
+            f"{missing_stats}. Supported stats: {supported}"
+        )
+
+    snapshot_paths: dict[str, Path] = {}
+    stat_configs: dict[str, PipelineConfig] = {}
+    skipped_stats: dict[str, str] = {}
+    failed_stats: dict[str, str] = {}
+    target_date: str | None = None
+
+    for stat, algolia_object_id in stat_ids.items():
+        try:
+            live_lines = import_ud_mlb_lines(algolia_object_id)
+        except Exception as exc:  # pragma: no cover - exercised in regression test
+            if not _is_expected_fetch_error(exc):
+                raise
+            failed_stats[stat] = str(exc)
+            continue
+
+        if live_lines.empty:
+            skipped_stats[stat] = "no live lines returned"
+            continue
+
+        line_date = _target_date_from_frame(live_lines)
+        target_date = line_date if target_date is None else min(target_date, line_date)
+        try:
+            snapshot_path = write_live_pitcher_prop_snapshot(
+                live_lines,
+                stat,
+                output_dir=args.snapshot_dir,
+                snapshot_date=line_date,
+            )
+        except OSError as exc:  # pragma: no cover - exercised in regression test
+            failed_stats[stat] = str(exc)
+            continue
+        try:
+            loaded = load_pipeline_config(
+                args.config,
+                sport_override="mlb",
+                stat_override=stat,
+            )
+        except (
+            OSError,
+            ConfigValidationError,
+            ValueError,
+        ) as exc:  # pragma: no cover - exercised in regression test
+            failed_stats[stat] = str(exc)
+            continue
+
+        snapshot_paths[stat] = snapshot_path
+        stat_configs[stat] = replace(
+            loaded,
+            section={**loaded.section, "lines_path": str(snapshot_path)},
+        )
+
+    slate_result = run_mlb_pitcher_prop_slate(
+        stat_configs,
+        retrain=bool(args.retrain),
+        stats=tuple(stat_configs),
+    )
+
+    skipped_stats.update(slate_result.skipped_stats)
+    failed_stats.update(slate_result.failed_stats)
+    if target_date is None:
+        target_date = datetime.utcnow().date().isoformat()
+
+    slip_cfg = SlipBuilderConfig(
+        top_n=int(args.top_n),
+        conservative_count=int(args.conservative_count),
+        fullsend_count=int(args.fullsend_count),
+    )
+    slip_sets = build_slip_sets(slate_result.combined_frame, config=slip_cfg)
+    slip_paths = write_slip_artifacts(
+        output_dir=args.output_dir,
+        prefix=args.prefix,
+        target_date=target_date,
+        slip_sets=slip_sets,
+        payload_common={
+            "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
+            "config_path": str(args.config),
+            "retrain": bool(args.retrain),
+        },
+    )
+
+    summary = {
+        "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
+        "config_path": str(args.config),
+        "target_date": target_date,
+        "stat_ids": stat_ids,
+        "completed_stats": list(slate_result.completed_stats),
+        "skipped_stats": skipped_stats,
+        "failed_stats": failed_stats,
+        "snapshot_files": {stat: str(path) for stat, path in snapshot_paths.items()},
+        "slip_files": {tag: str(path) for tag, path in slip_paths.items()},
+        "slip_counts": {tag: len(slips) for tag, slips in slip_sets.items()},
+        "combined_rows": int(len(slate_result.combined_frame)),
+        "output_dir": str(args.output_dir),
+        "snapshot_dir": str(args.snapshot_dir),
+    }
+
+    summary_path = args.output_dir / f"{args.prefix}_{target_date}_summary.json"
+    summary["summary_file"] = str(summary_path)
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main() -> dict[str, Any]:
+    """Run the MLB live shadow workflow."""
+
+    args = parse_args()
+    summary = run_live_shadow_workflow(args)
+    print(
+        "MLB live shadow run",
+        {
+            "target_date": summary["target_date"],
+            "completed_stats": summary["completed_stats"],
+            "combined_rows": summary["combined_rows"],
+            "slips": summary["slip_counts"],
+            "output_dir": summary["output_dir"],
+        },
+    )
+    return summary
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    main()

--- a/scripts/build_mlb_live_betslips.py
+++ b/scripts/build_mlb_live_betslips.py
@@ -18,18 +18,38 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from src.core.config import ConfigValidationError, load_pipeline_config
+from src.core.config import (
+    ConfigValidationError,
+    extract_mlb_live_underdog_config,
+    load_pipeline_config,
+)
 from src.core.contracts import PipelineConfig
 from src.mlb.data.underdog import import_ud_mlb_lines
 from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS
 from src.mlb.pitcher_props.live_lines import write_live_pitcher_prop_snapshot
 from src.mlb.pitcher_props.slate import run_mlb_pitcher_prop_slate
-from src.mlb.slips import SlipBuilderConfig, build_slip_sets
+from src.mlb.slips import SlipBuilderConfig, build_slip_sets, prepare_long_df
 
 DEFAULT_CONFIG_PATH = "config/mlb.yaml"
 DEFAULT_OUTPUT_DIR = Path("betslips/mlb_live")
 DEFAULT_SNAPSHOT_DIR = Path("data/lines")
 DEFAULT_PREFIX = "mlb_live"
+DEFAULT_MODE = "proof"
+STAT_MIX_DOMINANCE_THRESHOLD = 0.70
+PROBABILITY_MIN_THRESHOLD = 0.20
+PROBABILITY_MAX_THRESHOLD = 0.80
+EV_MAX_THRESHOLD = 0.35
+STAT_CONFIDENCE_THRESHOLDS: dict[str, dict[str, float]] = {
+    "strikeouts": {
+        "prob_min": PROBABILITY_MIN_THRESHOLD,
+        "prob_max": PROBABILITY_MAX_THRESHOLD,
+        "ev_max": EV_MAX_THRESHOLD,
+    },
+    "outs_recorded": {"prob_min": 0.15, "prob_max": 0.90, "ev_max": 0.60},
+    "earned_runs": {"prob_min": 0.15, "prob_max": 0.88, "ev_max": 0.55},
+    "hits_allowed": {"prob_min": 0.10, "prob_max": 0.93, "ev_max": 0.85},
+    "bb_allowed": {"prob_min": 0.15, "prob_max": 0.88, "ev_max": 0.55},
+}
 
 
 def _parse_stat_id_pairs(stat_id_args: list[str]) -> dict[str, str]:
@@ -67,6 +87,15 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default=DEFAULT_CONFIG_PATH,
         help="Path to the MLB config file used for stat pipelines.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("proof", "debug"),
+        default=DEFAULT_MODE,
+        help=(
+            "Run mode: proof requires full supported-market coverage; "
+            "debug allows subsets."
+        ),
     )
     parser.add_argument(
         "--output-dir",
@@ -120,6 +149,48 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _resolve_stat_ids(
+    config_path: str, stat_id_args: list[str], mode: str
+) -> dict[str, str]:
+    """Resolve live stat ids from config defaults plus CLI overrides."""
+
+    cli_stat_ids = _parse_stat_id_pairs(list(stat_id_args))
+    loaded = load_pipeline_config(
+        config_path,
+        sport_override="mlb",
+        stat_override="strikeouts",
+    )
+    live_underdog = extract_mlb_live_underdog_config(loaded)
+    stat_ids = {
+        stat.strip().lower(): object_id
+        for stat, object_id in live_underdog.stat_ids.items()
+        if str(object_id).strip()
+    }
+    stat_ids.update(cli_stat_ids)
+
+    missing_stats = sorted(stat for stat in stat_ids if stat not in STAT_DESCRIPTORS)
+    if missing_stats:
+        supported = ", ".join(sorted(STAT_DESCRIPTORS))
+        raise ValueError(
+            "Unsupported MLB stat-id mapping(s): "
+            f"{missing_stats}. Supported stats: {supported}"
+        )
+
+    if mode == "proof":
+        required_stats = tuple(sorted(STAT_DESCRIPTORS))
+        missing_required = [stat for stat in required_stats if stat not in stat_ids]
+        if missing_required:
+            raise ValueError(
+                "Missing required MLB stat-id mapping(s) for proof mode: "
+                f"{missing_required}"
+            )
+
+    if not stat_ids:
+        raise ValueError("At least one MLB stat-id mapping is required.")
+
+    return stat_ids
+
+
 def write_slip_artifacts(
     *,
     output_dir: Path,
@@ -138,6 +209,119 @@ def write_slip_artifacts(
         path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
         paths[tag] = path
     return paths
+
+
+def _humanize_stat(stat_id: object) -> str:
+    """Return a human-readable stat label."""
+
+    stat_text = str(stat_id or "").strip()
+    if not stat_text:
+        return "stat"
+    return stat_text.replace("_", " ")
+
+
+def _format_decimal(value: object, digits: int = 2) -> str:
+    """Return a compact decimal string for numeric values."""
+
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return "n/a"
+    text = f"{float(numeric):.{digits}f}"
+    return text.rstrip("0").rstrip(".")
+
+
+def _format_percent(value: object) -> str:
+    """Return a percentage string for a probability value."""
+
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return "n/a"
+    return f"{float(numeric) * 100:.1f}%"
+
+
+def _format_signed_decimal(value: object, digits: int = 2) -> str:
+    """Return a signed decimal string for numeric values."""
+
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return "n/a"
+    return f"{float(numeric):+.{digits}f}"
+
+
+def _predicted_value_for_leg(leg: dict[str, Any]) -> object:
+    """Return the best available model prediction for a slip leg."""
+
+    prediction_column = (
+        f"predicted_{str(leg.get('stat_id', '')).strip().lower()}" if leg else ""
+    )
+    if prediction_column and prediction_column in leg:
+        return leg.get(prediction_column)
+    return leg.get("predicted_value")
+
+
+def _format_leg_line(leg: dict[str, Any], index: int) -> str:
+    """Return a single human-readable line for a slip leg."""
+
+    player = str(leg.get("player") or leg.get("pitcher_name") or "Unknown player")
+    team = str(leg.get("team") or leg.get("pitcher_team") or "?")
+    opponent = str(leg.get("opponent") or leg.get("upcoming_opponent") or "?")
+    stat = _humanize_stat(leg.get("stat_id") or leg.get("market"))
+    play = str(leg.get("play") or "").lower()
+    line = _format_decimal(leg.get("line"), digits=1)
+    predicted = _format_decimal(_predicted_value_for_leg(leg))
+    prob = _format_percent(leg.get("prob"))
+    ev = _format_signed_decimal(leg.get("ev"))
+    return (
+        f"{index}. {player} ({team}) vs {opponent}: {stat} {play} {line} "
+        f"[model {predicted}, win {prob}, ev {ev}]"
+    )
+
+
+def render_slip_report(summary: dict[str, Any]) -> str:
+    """Return a human-readable report for generated slip artifacts."""
+
+    lines: list[str] = []
+    slip_files = summary.get("slip_files", {})
+    for tag in ("conservative", "fullsend"):
+        section_title = f"{tag.upper()} SLIPS"
+        lines.append(section_title)
+
+        path_text = slip_files.get(tag)
+        if not path_text:
+            lines.append("No artifact file recorded.")
+            lines.append("")
+            continue
+
+        path = Path(path_text)
+        if not path.exists():
+            lines.append(f"Missing artifact: {path}")
+            lines.append("")
+            continue
+
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        slips = payload.get("slips", [])
+        if not slips:
+            lines.append("None.")
+            lines.append("")
+            continue
+
+        for slip_index, slip in enumerate(slips, start=1):
+            lines.append(
+                " | ".join(
+                    [
+                        f"Slip {slip_index}",
+                        f"{int(slip.get('slip_size', len(slip.get('legs', []))))} legs",
+                        f"units {slip.get('units', 1)}",
+                        f"win {_format_percent(slip.get('p_win'))}",
+                        f"total ev {_format_signed_decimal(slip.get('total_ev'))}",
+                    ]
+                )
+            )
+            for leg_index, leg in enumerate(slip.get("legs", []), start=1):
+                lines.append(_format_leg_line(leg, leg_index))
+            lines.append("")
+
+    return "\n".join(lines).rstrip()
 
 
 def _target_date_from_frame(frame: pd.DataFrame) -> str:
@@ -164,19 +348,146 @@ def _is_expected_fetch_error(exc: Exception) -> bool:
     return isinstance(exc, OSError)
 
 
+def _slip_eligible_pool(
+    combined_frame: pd.DataFrame, slip_cfg: SlipBuilderConfig
+) -> pd.DataFrame:
+    """Return the ranked slip-eligible candidate pool."""
+
+    return prepare_long_df(
+        combined_frame,
+        top_n=int(slip_cfg.top_n),
+        min_ev=float(slip_cfg.min_leg_ev),
+    )
+
+
+def _stat_mix(pool: pd.DataFrame) -> dict[str, float]:
+    """Return stat share ratios for the slip-eligible pool."""
+
+    if pool.empty or "stat_id" not in pool.columns:
+        return {}
+
+    counts = pool["stat_id"].astype(str).value_counts(normalize=True).sort_index()
+    return {stat: float(share) for stat, share in counts.items()}
+
+
+def _probability_extremes(pool: pd.DataFrame) -> dict[str, float | None]:
+    """Return min/max probability values for the slip-eligible pool."""
+
+    if pool.empty or "prob" not in pool.columns:
+        return {"max": None, "min": None}
+
+    probs = pd.to_numeric(pool["prob"], errors="coerce").dropna()
+    if probs.empty:
+        return {"max": None, "min": None}
+    return {"max": float(probs.max()), "min": float(probs.min())}
+
+
+def _ev_extreme(pool: pd.DataFrame) -> dict[str, float | None]:
+    """Return the maximum EV value for the slip-eligible pool."""
+
+    if pool.empty or "ev" not in pool.columns:
+        return {"max": None}
+
+    evs = pd.to_numeric(pool["ev"], errors="coerce").dropna()
+    if evs.empty:
+        return {"max": None}
+    return {"max": float(evs.max())}
+
+
+def _confidence_thresholds_by_stat() -> dict[str, dict[str, float]]:
+    """Return configured confidence thresholds keyed by stat."""
+
+    return {
+        stat: dict(thresholds)
+        for stat, thresholds in STAT_CONFIDENCE_THRESHOLDS.items()
+    }
+
+
+def _confidence_gate_offenders(pool: pd.DataFrame) -> list[dict[str, Any]]:
+    """Return slip-eligible rows that violate stat-specific confidence bounds."""
+
+    if pool.empty:
+        return []
+
+    thresholds_by_stat = _confidence_thresholds_by_stat()
+    offenders: list[dict[str, Any]] = []
+    for row in pool.itertuples(index=False):
+        stat_id = str(getattr(row, "stat_id", "")).strip().lower()
+        thresholds = thresholds_by_stat.get(
+            stat_id,
+            {
+                "prob_min": PROBABILITY_MIN_THRESHOLD,
+                "prob_max": PROBABILITY_MAX_THRESHOLD,
+                "ev_max": EV_MAX_THRESHOLD,
+            },
+        )
+        prob = pd.to_numeric([getattr(row, "prob", pd.NA)], errors="coerce")[0]
+        ev = pd.to_numeric([getattr(row, "ev", pd.NA)], errors="coerce")[0]
+
+        reasons: list[str] = []
+        if pd.notna(prob) and float(prob) <= float(thresholds["prob_min"]):
+            reasons.append("prob_below_min")
+        if pd.notna(prob) and float(prob) >= float(thresholds["prob_max"]):
+            reasons.append("prob_above_max")
+        if pd.notna(ev) and float(ev) >= float(thresholds["ev_max"]):
+            reasons.append("ev_above_max")
+        if not reasons:
+            continue
+
+        line = pd.to_numeric([getattr(row, "line", pd.NA)], errors="coerce")[0]
+        offenders.append(
+            {
+                "player": str(getattr(row, "player", "")),
+                "stat_id": stat_id,
+                "line": float(line) if pd.notna(line) else None,
+                "prob": float(prob) if pd.notna(prob) else None,
+                "ev": float(ev) if pd.notna(ev) else None,
+                "reasons": reasons,
+                "thresholds": thresholds,
+            }
+        )
+    return offenders
+
+
+def _gate_failures(pool: pd.DataFrame) -> tuple[list[str], list[dict[str, Any]]]:
+    """Return proof-mode sanity gate failures for the slip-eligible pool."""
+
+    failures: list[str] = []
+    mix = _stat_mix(pool)
+    if mix and max(mix.values()) > STAT_MIX_DOMINANCE_THRESHOLD:
+        failures.append("stat_mix_gate_failed")
+
+    confidence_offenders = _confidence_gate_offenders(pool)
+    if confidence_offenders:
+        failures.append("confidence_gate_failed")
+
+    return failures, confidence_offenders
+
+
+def _summary_outcome(
+    *,
+    mode: str,
+    combined_rows: int,
+    slip_counts: dict[str, int],
+    gate_failures: list[str],
+) -> tuple[str, list[str]]:
+    """Return outcome tag plus failure reasons for the run summary."""
+
+    has_valid_slips = any(count > 0 for count in slip_counts.values())
+    if mode == "proof" and gate_failures:
+        return ("failed", gate_failures)
+    if combined_rows <= 0:
+        return ("failed", ["runtime_failure"])
+    if not has_valid_slips:
+        return ("no_play_slate", [])
+    return ("passed", [])
+
+
 def run_live_shadow_workflow(args: argparse.Namespace) -> dict[str, Any]:
     """Fetch live lines, score the slate, and emit JSON artifacts."""
 
-    stat_ids = _parse_stat_id_pairs(list(args.stat_ids))
-    if not stat_ids:
-        raise ValueError("At least one --stat-id mapping is required.")
-    missing_stats = sorted(stat for stat in stat_ids if stat not in STAT_DESCRIPTORS)
-    if missing_stats:
-        supported = ", ".join(sorted(STAT_DESCRIPTORS))
-        raise ValueError(
-            "Unsupported MLB stat-id mapping(s): "
-            f"{missing_stats}. Supported stats: {supported}"
-        )
+    mode = str(getattr(args, "mode", DEFAULT_MODE)).strip().lower() or DEFAULT_MODE
+    stat_ids = _resolve_stat_ids(args.config, list(args.stat_ids), mode)
 
     snapshot_paths: dict[str, Path] = {}
     stat_configs: dict[str, PipelineConfig] = {}
@@ -245,7 +556,17 @@ def run_live_shadow_workflow(args: argparse.Namespace) -> dict[str, Any]:
         conservative_count=int(args.conservative_count),
         fullsend_count=int(args.fullsend_count),
     )
+    slip_eligible_pool = _slip_eligible_pool(slate_result.combined_frame, slip_cfg)
     slip_sets = build_slip_sets(slate_result.combined_frame, config=slip_cfg)
+    slip_counts = {tag: len(slips) for tag, slips in slip_sets.items()}
+    gate_failures, confidence_offenders = _gate_failures(slip_eligible_pool)
+    outcome, failure_reasons = _summary_outcome(
+        mode=mode,
+        combined_rows=int(len(slate_result.combined_frame)),
+        slip_counts=slip_counts,
+        gate_failures=gate_failures,
+    )
+    warnings = gate_failures if mode == "debug" else []
     slip_paths = write_slip_artifacts(
         output_dir=args.output_dir,
         prefix=args.prefix,
@@ -260,16 +581,26 @@ def run_live_shadow_workflow(args: argparse.Namespace) -> dict[str, Any]:
 
     summary = {
         "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
+        "mode": mode,
         "config_path": str(args.config),
         "target_date": target_date,
         "stat_ids": stat_ids,
+        "outcome": outcome,
+        "failure_reasons": failure_reasons,
+        "warnings": warnings,
         "completed_stats": list(slate_result.completed_stats),
         "skipped_stats": skipped_stats,
         "failed_stats": failed_stats,
         "snapshot_files": {stat: str(path) for stat, path in snapshot_paths.items()},
         "slip_files": {tag: str(path) for tag, path in slip_paths.items()},
-        "slip_counts": {tag: len(slips) for tag, slips in slip_sets.items()},
+        "slip_counts": slip_counts,
         "combined_rows": int(len(slate_result.combined_frame)),
+        "slip_eligible_rows": int(len(slip_eligible_pool)),
+        "stat_mix": _stat_mix(slip_eligible_pool),
+        "probability_extremes": _probability_extremes(slip_eligible_pool),
+        "ev_extreme": _ev_extreme(slip_eligible_pool),
+        "confidence_thresholds": _confidence_thresholds_by_stat(),
+        "confidence_gate_offenders": confidence_offenders,
         "output_dir": str(args.output_dir),
         "snapshot_dir": str(args.snapshot_dir),
     }
@@ -298,6 +629,7 @@ def main() -> dict[str, Any]:
             "output_dir": summary["output_dir"],
         },
     )
+    print(render_slip_report(summary))
     return summary
 
 

--- a/scripts/print_slips.py
+++ b/scripts/print_slips.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# ruff: noqa: I001, E402
+"""Print saved MLB live slip artifacts in a human-readable format."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.mlb.slip_report import load_summary, render_slip_report
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the slip-printer script.
+
+    Returns:
+        Parsed CLI namespace.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Print saved MLB live slip artifacts in a readable format.",
+    )
+    parser.add_argument(
+        "summary_path",
+        type=Path,
+        help="Path to an MLB live summary JSON artifact.",
+    )
+    parser.add_argument(
+        "--tag",
+        choices=("conservative", "fullsend"),
+        default=None,
+        help="Optional slip set to print. Defaults to all saved sets.",
+    )
+    return parser.parse_args()
+
+
+def main() -> str:
+    """Load a summary artifact and print its saved slips.
+
+    Returns:
+        Rendered slip report text.
+    """
+
+    args = parse_args()
+    summary = load_summary(Path(args.summary_path))
+    tags = (args.tag,) if args.tag else None
+    report = render_slip_report(summary, tags=tags)
+    print(report)
+    return report
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    main()

--- a/scripts/report_mlb_proof_gate_calibration.py
+++ b/scripts/report_mlb_proof_gate_calibration.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+# ruff: noqa: I001, E402
+"""Build a lightweight calibration report for MLB proof-run confidence gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+import sys
+from typing import Any
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.build_mlb_live_betslips import _confidence_thresholds_by_stat
+from src.mlb.models.strategy import predict_with_strategy_artifact
+from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS, get_stat_descriptor
+from src.mlb.pitcher_props.pipeline import (
+    _build_training_games,
+    _clean_for_model,
+    _model_features,
+    _train_or_load,
+)
+from src.utils.io import load_config
+
+DEFAULT_CONFIG_PATH = "config/mlb.yaml"
+DEFAULT_LINES_DIR = Path("data/lines")
+DEFAULT_OUTPUT_PATH = Path("models/mlb_proof_gate_calibration.json")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI args for proof-gate calibration reporting."""
+
+    parser = argparse.ArgumentParser(
+        description="Report quick MLB proof-gate calibration diagnostics.",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to the MLB config file.",
+    )
+    parser.add_argument(
+        "--lines-dir",
+        type=Path,
+        default=DEFAULT_LINES_DIR,
+        help="Directory containing dated live line snapshots.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Where to write the calibration JSON report.",
+    )
+    parser.add_argument(
+        "--stat",
+        action="append",
+        dest="stats",
+        default=[],
+        help="Limit the report to one or more MLB prop stats.",
+    )
+    return parser.parse_args()
+
+
+def _snapshot_paths(lines_dir: Path, stat: str) -> list[Path]:
+    """Return sorted dated snapshot paths for a stat."""
+
+    return sorted(lines_dir.glob(f"{stat}_20??-??-??.csv"))
+
+
+def _line_distribution_stats(
+    lines: pd.Series,
+    actual: pd.Series,
+) -> list[dict[str, float | int]]:
+    """Return empirical under/over rates for each unique live line level."""
+
+    distribution: list[dict[str, float | int]] = []
+    clean_actual = pd.to_numeric(actual, errors="coerce").dropna()
+    if clean_actual.empty:
+        return distribution
+
+    for line_value in sorted(
+        pd.to_numeric(lines, errors="coerce").dropna().astype(float).unique().tolist()
+    ):
+        distribution.append(
+            {
+                "line": float(line_value),
+                "empirical_under_rate": float((clean_actual < line_value).mean()),
+                "empirical_over_rate": float((clean_actual > line_value).mean()),
+                "sample_size": int(clean_actual.shape[0]),
+            }
+        )
+    return distribution
+
+
+def _stat_report(
+    *,
+    stat: str,
+    section: dict[str, Any],
+    lines_dir: Path,
+) -> dict[str, Any]:
+    """Build calibration diagnostics for one stat."""
+
+    descriptor = get_stat_descriptor(stat)
+    training_games = _build_training_games(section, descriptor)
+    model_frame = _clean_for_model(training_games, descriptor)
+    model, model_name, strategy_name = _train_or_load(
+        model_frame,
+        section=section,
+        descriptor=descriptor,
+        retrain=False,
+    )
+    actual = pd.to_numeric(model_frame[descriptor.target_col], errors="coerce")
+    predicted = pd.to_numeric(
+        predict_with_strategy_artifact(
+            model_frame,
+            features=_model_features(descriptor),
+            name="prediction",
+            artifact=model,
+        ),
+        errors="coerce",
+    )
+    residuals = actual - predicted
+
+    snapshots: list[dict[str, Any]] = []
+    for path in _snapshot_paths(lines_dir, stat):
+        frame = pd.read_csv(path)
+        if descriptor.line_col not in frame.columns:
+            continue
+        lines = pd.to_numeric(frame[descriptor.line_col], errors="coerce")
+        snapshots.append(
+            {
+                "path": str(path),
+                "date": path.stem.removeprefix(f"{stat}_"),
+                "rows": int(len(frame)),
+                "line_min": float(lines.min()) if lines.notna().any() else None,
+                "line_max": float(lines.max()) if lines.notna().any() else None,
+                "line_levels": _line_distribution_stats(lines, actual),
+            }
+        )
+
+    return {
+        "stat": stat,
+        "model_name": model_name,
+        "strategy_name": strategy_name,
+        "thresholds": _confidence_thresholds_by_stat().get(stat, {}),
+        "training_rows": int(len(model_frame)),
+        "actual_mean": float(actual.mean()),
+        "actual_std": float(actual.std(ddof=1)),
+        "predicted_mean": float(predicted.mean()),
+        "predicted_std": float(predicted.std(ddof=1)),
+        "residual_std": float(residuals.std(ddof=1)),
+        "mae": float((actual - predicted).abs().mean()),
+        "p90_actual": float(actual.quantile(0.90)),
+        "p90_predicted": float(predicted.quantile(0.90)),
+        "snapshots": snapshots,
+    }
+
+
+def main() -> dict[str, Any]:
+    """Write and return the proof-gate calibration report."""
+
+    args = parse_args()
+    config = load_config(args.config)
+    stats = [stat.strip().lower() for stat in args.stats] or list(STAT_DESCRIPTORS)
+    invalid = sorted(stat for stat in stats if stat not in STAT_DESCRIPTORS)
+    if invalid:
+        raise ValueError(f"Unsupported stats: {invalid}")
+
+    report = {
+        "generated_at": datetime.utcnow().isoformat(timespec="seconds"),
+        "config_path": str(args.config),
+        "lines_dir": str(args.lines_dir),
+        "stats": [
+            _stat_report(
+                stat=stat,
+                section=dict(config["mlb"][stat]),
+                lines_dir=args.lines_dir,
+            )
+            for stat in stats
+        ],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    print(json.dumps({"output": str(args.output), "stats": stats}, sort_keys=True))
+    return report
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from numbers import Integral
 from pathlib import Path
 from typing import Any
@@ -25,10 +26,35 @@ _MLB_RUNTIME_CRITICAL_STATS: frozenset[str] = frozenset(
     }
 )
 _MLB_REQUIRED_KEYS: tuple[str, ...] = ("pitch_data_path", "model_path", "lines_path")
+_MLB_LIVE_UNDERDOG_DEFAULT_SNAPSHOT_OUTPUT_DIR = "data/lines"
+_MLB_LIVE_UNDERDOG_DEFAULT_SNAPSHOT_FILENAME_TEMPLATE = "{stat}_{date}.csv"
+_MLB_LIVE_UNDERDOG_DEFAULT_ORCHESTRATION_DEFAULTS: dict[str, Any] = {
+    "same_pitcher_stacking": True,
+    "min_players_per_slip": 2,
+    "min_teams_per_slip": 2,
+    "json_only": True,
+}
 _SECTIONED_SCHEMA_MESSAGE = (
     "Config must use sectioned schema. Required fields: 'pipeline.sport', "
     "'pipeline.stat', and '{sport}.{stat}'. Legacy flat config is not supported."
 )
+
+
+@dataclass(slots=True)
+class MlbLiveUnderdogConfig:
+    """Normalized MLB live Underdog orchestration config.
+
+    Attributes:
+        stat_ids: Mapping of MLB stat name to Underdog ``PickemStat_*`` id.
+        snapshot_output_dir: Directory where dated line snapshots are written.
+        snapshot_filename_template: Filename template for dated snapshots.
+        orchestration_defaults: Shared slip-generation defaults.
+    """
+
+    stat_ids: dict[str, str]
+    snapshot_output_dir: str
+    snapshot_filename_template: str
+    orchestration_defaults: dict[str, Any]
 
 
 def _validate_sectioned_schema_root(raw_config: dict[str, Any]) -> dict[str, Any]:
@@ -281,6 +307,174 @@ def _validate_nhl_shots_on_goal_section(section: dict[str, Any], path: str) -> N
             )
 
 
+def _normalize_mlb_live_underdog_defaults(
+    section: dict[str, Any] | None,
+) -> MlbLiveUnderdogConfig:
+    """Normalize the optional MLB live Underdog config block.
+
+    Args:
+        section: Optional `mlb.live_underdog` mapping.
+
+    Returns:
+        Normalized MLB live Underdog config payload.
+
+    Raises:
+        ConfigValidationError: If a provided live Underdog subsection has an
+            invalid type.
+    """
+
+    if section is None:
+        return MlbLiveUnderdogConfig(
+            stat_ids={},
+            snapshot_output_dir=_MLB_LIVE_UNDERDOG_DEFAULT_SNAPSHOT_OUTPUT_DIR,
+            snapshot_filename_template=(
+                _MLB_LIVE_UNDERDOG_DEFAULT_SNAPSHOT_FILENAME_TEMPLATE
+            ),
+            orchestration_defaults=dict(
+                _MLB_LIVE_UNDERDOG_DEFAULT_ORCHESTRATION_DEFAULTS
+            ),
+        )
+
+    stat_ids_raw = section.get("stat_ids", {})
+    if not isinstance(stat_ids_raw, dict):
+        raise ConfigValidationError(
+            "Invalid optional field 'mlb.live_underdog.stat_ids': expected mapping."
+        )
+
+    stat_ids: dict[str, str] = {}
+    for stat, raw_object_id in stat_ids_raw.items():
+        if not isinstance(stat, str) or not stat.strip():
+            raise ConfigValidationError(
+                "Invalid optional field 'mlb.live_underdog.stat_ids': "
+                "expected non-empty stat names."
+            )
+        stat_name = stat.strip().lower()
+        if stat_name not in _MLB_RUNTIME_CRITICAL_STATS:
+            raise ConfigValidationError(
+                "Invalid optional field 'mlb.live_underdog.stat_ids."
+                f"{stat_name}': unsupported MLB stat."
+            )
+        if not isinstance(raw_object_id, str) or not raw_object_id.strip():
+            raise ConfigValidationError(
+                "Invalid optional field 'mlb.live_underdog.stat_ids."
+                f"{stat_name}': expected non-empty string."
+            )
+        stat_ids[stat_name] = raw_object_id.strip()
+
+    snapshot_output_dir_raw = section.get("snapshot_output_dir")
+    if snapshot_output_dir_raw is None:
+        snapshot_output_dir = _MLB_LIVE_UNDERDOG_DEFAULT_SNAPSHOT_OUTPUT_DIR
+    elif not isinstance(snapshot_output_dir_raw, str) or not (
+        snapshot_output_dir_raw.strip()
+    ):
+        raise ConfigValidationError(
+            "Invalid optional field 'mlb.live_underdog.snapshot_output_dir': "
+            "expected non-empty string."
+        )
+    else:
+        snapshot_output_dir = snapshot_output_dir_raw.strip()
+
+    snapshot_filename_template_raw = section.get("snapshot_filename_template")
+    if snapshot_filename_template_raw is None:
+        snapshot_filename_template = (
+            _MLB_LIVE_UNDERDOG_DEFAULT_SNAPSHOT_FILENAME_TEMPLATE
+        )
+    elif (
+        not isinstance(snapshot_filename_template_raw, str)
+        or not snapshot_filename_template_raw.strip()
+    ):
+        raise ConfigValidationError(
+            "Invalid optional field 'mlb.live_underdog.snapshot_filename_template': "
+            "expected non-empty string."
+        )
+    else:
+        snapshot_filename_template = snapshot_filename_template_raw.strip()
+
+    orchestration_defaults_raw = section.get("orchestration_defaults", {})
+    if not isinstance(orchestration_defaults_raw, dict):
+        raise ConfigValidationError(
+            "Invalid optional field 'mlb.live_underdog.orchestration_defaults': "
+            "expected mapping."
+        )
+
+    orchestration_defaults = _validate_mlb_live_underdog_orchestration_defaults(
+        orchestration_defaults_raw
+    )
+
+    return MlbLiveUnderdogConfig(
+        stat_ids=stat_ids,
+        snapshot_output_dir=snapshot_output_dir,
+        snapshot_filename_template=snapshot_filename_template,
+        orchestration_defaults=orchestration_defaults,
+    )
+
+
+def _validate_mlb_live_underdog_orchestration_defaults(
+    section: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate live Underdog orchestration defaults and apply fallback values."""
+
+    defaults = dict(_MLB_LIVE_UNDERDOG_DEFAULT_ORCHESTRATION_DEFAULTS)
+
+    same_pitcher_stacking = section.get("same_pitcher_stacking")
+    if same_pitcher_stacking is not None:
+        if not isinstance(same_pitcher_stacking, bool):
+            raise ConfigValidationError(
+                "Invalid optional field "
+                "'mlb.live_underdog.orchestration_defaults.same_pitcher_stacking': "
+                "expected boolean."
+            )
+        defaults["same_pitcher_stacking"] = same_pitcher_stacking
+
+    min_players_per_slip = section.get("min_players_per_slip")
+    if min_players_per_slip is not None:
+        if isinstance(min_players_per_slip, bool) or not isinstance(
+            min_players_per_slip, Integral
+        ):
+            raise ConfigValidationError(
+                "Invalid optional field "
+                "'mlb.live_underdog.orchestration_defaults.min_players_per_slip': "
+                "expected integer >= 1."
+            )
+        if int(min_players_per_slip) < 1:
+            raise ConfigValidationError(
+                "Invalid optional field "
+                "'mlb.live_underdog.orchestration_defaults.min_players_per_slip': "
+                "expected integer >= 1."
+            )
+        defaults["min_players_per_slip"] = int(min_players_per_slip)
+
+    min_teams_per_slip = section.get("min_teams_per_slip")
+    if min_teams_per_slip is not None:
+        if isinstance(min_teams_per_slip, bool) or not isinstance(
+            min_teams_per_slip, Integral
+        ):
+            raise ConfigValidationError(
+                "Invalid optional field "
+                "'mlb.live_underdog.orchestration_defaults.min_teams_per_slip': "
+                "expected integer >= 1."
+            )
+        if int(min_teams_per_slip) < 1:
+            raise ConfigValidationError(
+                "Invalid optional field "
+                "'mlb.live_underdog.orchestration_defaults.min_teams_per_slip': "
+                "expected integer >= 1."
+            )
+        defaults["min_teams_per_slip"] = int(min_teams_per_slip)
+
+    json_only = section.get("json_only")
+    if json_only is not None:
+        if not isinstance(json_only, bool):
+            raise ConfigValidationError(
+                "Invalid optional field "
+                "'mlb.live_underdog.orchestration_defaults.json_only': "
+                "expected boolean."
+            )
+        defaults["json_only"] = json_only
+
+    return defaults
+
+
 _VALIDATORS: dict[tuple[str, str], Callable[[dict[str, Any], str], None]] = {
     **{
         ("mlb", stat): _validate_mlb_stat_section
@@ -370,3 +564,34 @@ def load_pipeline_config(
         raw=raw,
         section=section,
     )
+
+
+def extract_mlb_live_underdog_config(
+    config: PipelineConfig | dict[str, Any],
+) -> MlbLiveUnderdogConfig:
+    """Return normalized MLB live Underdog config from a pipeline config.
+
+    Args:
+        config: Validated pipeline config or raw config mapping.
+
+    Returns:
+        Normalized live Underdog configuration with defaults applied.
+    """
+
+    raw_config = config.raw if isinstance(config, PipelineConfig) else config
+    if not isinstance(raw_config, dict):
+        raise ConfigValidationError("Config root must be a mapping.")
+
+    mlb_section = raw_config.get("mlb")
+    if not isinstance(mlb_section, dict):
+        return _normalize_mlb_live_underdog_defaults(None)
+
+    live_underdog_section = mlb_section.get("live_underdog")
+    if live_underdog_section is None:
+        return _normalize_mlb_live_underdog_defaults(None)
+    if not isinstance(live_underdog_section, dict):
+        raise ConfigValidationError(
+            "Invalid optional field 'mlb.live_underdog': expected mapping."
+        )
+
+    return _normalize_mlb_live_underdog_defaults(live_underdog_section)

--- a/src/mlb/data/__init__.py
+++ b/src/mlb/data/__init__.py
@@ -4,5 +4,10 @@ from .load_pitcher_stats import (
     load_pitcher_game_logs as load_pitcher_game_logs,
 )
 from .load_props import load_strikeout_lines as load_strikeout_lines
+from .underdog import import_ud_mlb_lines as import_ud_mlb_lines
 
-__all__ = ["load_pitcher_game_logs", "load_strikeout_lines"]
+__all__ = [
+    "import_ud_mlb_lines",
+    "load_pitcher_game_logs",
+    "load_strikeout_lines",
+]

--- a/src/mlb/data/load_props.py
+++ b/src/mlb/data/load_props.py
@@ -1,9 +1,9 @@
-"""Helpers for loading Underdog strikeout prop lines."""
+"""Helpers for loading MLB pitcher prop lines."""
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import numpy as np
 import pandas as pd
@@ -25,6 +25,51 @@ def _coerce_numeric(df: pd.DataFrame, columns: Iterable[str]) -> None:
         df[column] = pd.to_numeric(df[column], errors="coerce")
 
 
+def normalize_pitcher_prop_lines(df: pd.DataFrame, line_col: str) -> pd.DataFrame:
+    """Normalize a pitcher-prop line frame for downstream loaders.
+
+    Args:
+        df: Raw line frame.
+        line_col: Stat-specific line column name.
+
+    Returns:
+        Normalized line frame with required numeric columns coerced.
+
+    Raises:
+        ValueError: If required columns are missing.
+    """
+
+    work = df.copy()
+    required = {"player", line_col}
+    missing = required - set(work.columns)
+    if missing:
+        raise ValueError(
+            f"Pitcher prop lines missing required columns: {sorted(missing)}"
+        )
+
+    for optional in (
+        "over_decimal_price",
+        "over_payout_multiplier",
+        "under_decimal_price",
+        "under_payout_multiplier",
+    ):
+        if optional not in work.columns:
+            work[optional] = np.nan
+
+    _coerce_numeric(
+        work,
+        [
+            line_col,
+            "over_decimal_price",
+            "over_payout_multiplier",
+            "under_decimal_price",
+            "under_payout_multiplier",
+        ],
+    )
+    work["player"] = work["player"].astype(str)
+    return work
+
+
 def load_strikeout_lines(path: str) -> pd.DataFrame:
     """Load raw Underdog strikeout lines and coerce numeric odds columns."""
 
@@ -41,17 +86,7 @@ def load_strikeout_lines(path: str) -> pd.DataFrame:
     if missing:
         raise ValueError(f"Strikeout lines missing required columns: {sorted(missing)}")
 
-    numeric_columns = [
-        "k_line",
-        "over_decimal_price",
-        "over_payout_multiplier",
-        "under_decimal_price",
-        "under_payout_multiplier",
-    ]
-    _coerce_numeric(df, numeric_columns)
-
-    df["player"] = df["player"].astype(str)
-    return df
+    return normalize_pitcher_prop_lines(df, "k_line")
 
 
 def load_pitcher_prop_lines(path: str, line_col: str) -> pd.DataFrame:
@@ -74,17 +109,4 @@ def load_pitcher_prop_lines(path: str, line_col: str) -> pd.DataFrame:
     else:
         df = read_csv(str(file_path))
 
-    required = {"player", line_col}
-    missing = required - set(df.columns)
-    if missing:
-        raise ValueError(
-            f"Pitcher prop lines missing required columns: {sorted(missing)}"
-        )
-
-    for optional in ("over_decimal_price", "under_decimal_price"):
-        if optional not in df.columns:
-            df[optional] = np.nan  # type: ignore[name-defined]
-
-    _coerce_numeric(df, [line_col, "over_decimal_price", "under_decimal_price"])
-    df["player"] = df["player"].astype(str)
-    return df
+    return normalize_pitcher_prop_lines(df, line_col)

--- a/src/mlb/data/underdog.py
+++ b/src/mlb/data/underdog.py
@@ -1,0 +1,167 @@
+"""Underdog ingestion helpers for MLB pitcher props."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import re
+from typing import Any
+from urllib.parse import urlencode
+
+import pandas as pd
+
+UNDERDOG_HOST = "api.underdogfantasy.com"
+UNDERDOG_PATH = "/v2/pickem_search/search_results"
+_ALGOLIA_OBJECT_ID_PATTERN = re.compile(r"^PickemStat_[^\s]+$")
+_LINE_COLUMNS: tuple[str, ...] = (
+    "appearance_id",
+    "player_ud_id",
+    "player_name",
+    "game_id",
+    "team_id",
+    "line",
+    "book",
+    "scheduled_at",
+    "season_type",
+    "stat_id",
+    "over_decimal_price",
+    "over_payout_multiplier",
+    "over_american_price",
+    "under_decimal_price",
+    "under_payout_multiplier",
+    "under_american_price",
+)
+_NUMERIC_COLUMNS: tuple[str, ...] = (
+    "line",
+    "over_decimal_price",
+    "over_payout_multiplier",
+    "under_decimal_price",
+    "under_payout_multiplier",
+)
+
+
+def _fetch_payload(algolia_object_id: str) -> dict[str, Any]:
+    """Fetch the raw Underdog payload for the given Algolia object id."""
+
+    query = urlencode({"sport_id": "HOME", "algolia_object_id": algolia_object_id})
+    connection = http.client.HTTPSConnection(UNDERDOG_HOST, timeout=15)
+    try:
+        connection.request(
+            "GET",
+            f"{UNDERDOG_PATH}?{query}",
+            headers={"User-Agent": "Mozilla/5.0"},
+        )
+        response = connection.getresponse()
+        if response.status >= 400:
+            raise RuntimeError(
+                f"Underdog API request failed with status {response.status}."
+            )
+        payload = response.read()
+        return json.loads(payload.decode("utf-8"))
+    finally:
+        connection.close()
+
+
+def _stat_id_from_algolia_object_id(algolia_object_id: str) -> str:
+    """Return the pick'em stat id encoded in the Algolia object id."""
+
+    if not _ALGOLIA_OBJECT_ID_PATTERN.fullmatch(algolia_object_id):
+        raise ValueError(
+            "Invalid Underdog Algolia object id: expected 'PickemStat_<stat-id>'."
+        )
+
+    return algolia_object_id.split("_", maxsplit=1)[-1]
+
+
+def _selection_value(options: list[dict[str, Any]], choice: str) -> dict[str, Any]:
+    """Return the first matching choice option from an Underdog line payload."""
+
+    return next((opt for opt in options if opt.get("choice") == choice), {})
+
+
+def _extract_lines(payload: dict[str, Any], stat_id: str) -> pd.DataFrame:
+    """Parse Over/Under lines for a specific MLB pick'em stat id."""
+
+    appearances = {
+        appearance.get("id"): appearance
+        for appearance in payload.get("appearances", [])
+        if appearance.get("id")
+    }
+    games = {
+        game.get("id"): game for game in payload.get("games", []) if game.get("id")
+    }
+    players = {
+        player.get("id"): player
+        for player in payload.get("players", [])
+        if player.get("id")
+    }
+
+    rows: list[dict[str, Any]] = []
+    for line in payload.get("over_under_lines", []):
+        over_under = line.get("over_under") or {}
+        appearance_stat = over_under.get("appearance_stat") or {}
+        if appearance_stat.get("pickem_stat_id") != stat_id:
+            continue
+
+        appearance_id = (
+            appearance_stat.get("appearance_id") or line.get("appearance_id")
+        )
+        if not appearance_id:
+            continue
+
+        appearance = appearances.get(appearance_id)
+        if appearance is None:
+            continue
+
+        player = players.get(appearance.get("player_id")) or {}
+        first = str(player.get("first_name") or "").strip()
+        last = str(player.get("last_name") or "").strip()
+        player_name = f"{first} {last}".strip()
+        if not player_name:
+            player_name = str(
+                (line.get("options") or [{}])[0].get("selection_header") or ""
+            ).strip()
+        if not player_name:
+            continue
+
+        options = list(line.get("options") or [])
+        higher_option = _selection_value(options, "higher")
+        lower_option = _selection_value(options, "lower")
+        game = games.get(appearance.get("match_id")) or {}
+
+        rows.append(
+            {
+                "appearance_id": str(appearance_id),
+                "player_ud_id": str(appearance.get("player_id") or ""),
+                "player_name": player_name,
+                "game_id": str(appearance.get("match_id") or ""),
+                "team_id": str(appearance.get("team_id") or ""),
+                "line": line.get("stat_value"),
+                "book": "Underdog",
+                "scheduled_at": game.get("scheduled_at"),
+                "season_type": game.get("season_type"),
+                "stat_id": stat_id,
+                "over_decimal_price": higher_option.get("decimal_price"),
+                "over_payout_multiplier": higher_option.get("payout_multiplier"),
+                "over_american_price": higher_option.get("american_price"),
+                "under_decimal_price": lower_option.get("decimal_price"),
+                "under_payout_multiplier": lower_option.get("payout_multiplier"),
+                "under_american_price": lower_option.get("american_price"),
+            }
+        )
+
+    frame = pd.DataFrame(rows, columns=_LINE_COLUMNS)
+    if frame.empty:
+        return frame
+
+    for column in _NUMERIC_COLUMNS:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    return frame
+
+
+def import_ud_mlb_lines(algolia_object_id: str) -> pd.DataFrame:
+    """Return MLB Underdog lines as a tidy DataFrame."""
+
+    stat_id = _stat_id_from_algolia_object_id(algolia_object_id)
+    payload = _fetch_payload(algolia_object_id)
+    return _extract_lines(payload, stat_id)

--- a/src/mlb/data/underdog.py
+++ b/src/mlb/data/underdog.py
@@ -79,6 +79,54 @@ def _selection_value(options: list[dict[str, Any]], choice: str) -> dict[str, An
     return next((opt for opt in options if opt.get("choice") == choice), {})
 
 
+def _player_full_name(player: dict[str, Any]) -> str:
+    """Return the normalized full name for a player payload row."""
+
+    first = str(player.get("first_name") or "").strip()
+    last = str(player.get("last_name") or "").strip()
+    return f"{first} {last}".strip()
+
+
+def _resolve_appearance(
+    *,
+    line: dict[str, Any],
+    appearance_stat: dict[str, Any],
+    appearances: dict[str, dict[str, Any]],
+    appearance_by_player_id: dict[str, dict[str, Any]],
+    player_id_by_name: dict[str, str],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve the best available appearance id and appearance payload."""
+
+    appearance_id = appearance_stat.get("appearance_id") or line.get("appearance_id")
+    appearance = appearances.get(appearance_id)
+    if appearance is not None:
+        return str(appearance_id), appearance
+
+    selection_header = str(
+        (line.get("options") or [{}])[0].get("selection_header") or ""
+    ).strip()
+    if not selection_header:
+        return (
+            str(appearance_id) if appearance_id is not None else None,
+            None,
+        )
+
+    player_id = player_id_by_name.get(selection_header)
+    if not player_id:
+        return (
+            str(appearance_id) if appearance_id is not None else None,
+            None,
+        )
+
+    fallback_appearance = appearance_by_player_id.get(player_id)
+    if fallback_appearance is None:
+        return (
+            str(appearance_id) if appearance_id is not None else None,
+            None,
+        )
+    return str(fallback_appearance.get("id") or appearance_id), fallback_appearance
+
+
 def _extract_lines(payload: dict[str, Any], stat_id: str) -> pd.DataFrame:
     """Parse Over/Under lines for a specific MLB pick'em stat id."""
 
@@ -95,6 +143,16 @@ def _extract_lines(payload: dict[str, Any], stat_id: str) -> pd.DataFrame:
         for player in payload.get("players", [])
         if player.get("id")
     }
+    appearance_by_player_id = {
+        str(appearance.get("player_id")): appearance
+        for appearance in payload.get("appearances", [])
+        if appearance.get("player_id")
+    }
+    player_id_by_name = {
+        name: str(player_id)
+        for player_id, player in players.items()
+        if (name := _player_full_name(player))
+    }
 
     rows: list[dict[str, Any]] = []
     for line in payload.get("over_under_lines", []):
@@ -103,20 +161,18 @@ def _extract_lines(payload: dict[str, Any], stat_id: str) -> pd.DataFrame:
         if appearance_stat.get("pickem_stat_id") != stat_id:
             continue
 
-        appearance_id = (
-            appearance_stat.get("appearance_id") or line.get("appearance_id")
+        appearance_id, appearance = _resolve_appearance(
+            line=line,
+            appearance_stat=appearance_stat,
+            appearances=appearances,
+            appearance_by_player_id=appearance_by_player_id,
+            player_id_by_name=player_id_by_name,
         )
-        if not appearance_id:
-            continue
-
-        appearance = appearances.get(appearance_id)
         if appearance is None:
             continue
 
         player = players.get(appearance.get("player_id")) or {}
-        first = str(player.get("first_name") or "").strip()
-        last = str(player.get("last_name") or "").strip()
-        player_name = f"{first} {last}".strip()
+        player_name = _player_full_name(player)
         if not player_name:
             player_name = str(
                 (line.get("options") or [{}])[0].get("selection_header") or ""

--- a/src/mlb/features/live_context.py
+++ b/src/mlb/features/live_context.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -83,6 +85,8 @@ class LiveContextService:
         self.secondary_weather_source = str(
             weather_cfg.get("secondary_source", "statsapi_game_feed")
         )
+        self._schedule_cache: dict[tuple[int, str], pd.DataFrame | None] = {}
+        self._schedule_cache_lock = threading.Lock()
 
     def fetch(
         self, rows: pd.DataFrame, target_date: datetime
@@ -388,65 +392,46 @@ class LiveContextService:
         if schedule_and_record is None:
             return pd.DataFrame()
 
+        target_day = pd.Timestamp(target_date).normalize()
+        unique_opponents = sorted(
+            {
+                str(opponent).strip()
+                for opponent in rows.get("opponent_team", pd.Series(dtype=object))
+                if str(opponent).strip()
+            }
+        )
+        if not unique_opponents:
+            return pd.DataFrame()
+
+        max_workers = min(8, len(unique_opponents))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            opponent_payloads = dict(
+                zip(
+                    unique_opponents,
+                    executor.map(
+                        lambda opponent: self._primary_payload_for_opponent(
+                            opponent,
+                            target_date.year,
+                            target_day,
+                        ),
+                        unique_opponents,
+                    ),
+                )
+            )
+
         records: list[dict[str, Any]] = []
         for row in rows.itertuples(index=False):
             opponent = str(getattr(row, "opponent_team", "")).strip()
             if not opponent:
                 continue
+            opponent_payload = opponent_payloads.get(opponent)
+            if opponent_payload is None:
+                continue
             payload: dict[str, Any] = {
                 "pitcher_id": getattr(row, "pitcher_id", None),
                 "opponent_team": opponent,
             }
-            try:
-                schedule = schedule_and_record(target_date.year, opponent)
-                if schedule is not None and not schedule.empty:
-                    schedule = schedule.copy()
-                    if "Date" not in schedule.columns:
-                        continue
-                    schedule["game_date"] = schedule["Date"].map(
-                        lambda value: _coerce_schedule_date(value, target_date.year)
-                    )
-                    target_day = pd.Timestamp(target_date).normalize()
-                    same_day = schedule[
-                        schedule["game_date"].dt.normalize() == target_day
-                    ]
-                    if same_day.empty:
-                        continue
-                    weather_row = same_day.iloc[0].to_dict()
-                    wind_speed, wind_direction = _extract_wind_components(
-                        weather_row.get("Wind")
-                    )
-                    weather = normalize_weather_payload(
-                        {
-                            "game_temp_f": weather_row.get("Temp")
-                            or weather_row.get("temperature"),
-                            "wind_speed_mph": wind_speed
-                            or weather_row.get("wind_speed_mph"),
-                            "humidity_pct": weather_row.get("Humidity")
-                            or weather_row.get("humidity_pct"),
-                            "wind_direction": weather_row.get("WindDir")
-                            or wind_direction
-                            or weather_row.get("wind_direction"),
-                        },
-                        use_defaults=False,
-                    )
-                    payload.update(weather)
-                else:
-                    payload.update(normalize_weather_payload({}, use_defaults=False))
-
-                venue = normalize_venue_payload({"roof_state": None})
-                payload.update(venue)
-                weather_values = [
-                    payload.get("game_temp_f"),
-                    payload.get("humidity_pct"),
-                    payload.get("wind_speed_mph"),
-                ]
-                payload["weather_known_flag"] = int(
-                    all(pd.notna(value) for value in weather_values)
-                )
-            except Exception:
-                logger.debug("Primary live feature fetch failed for team=%s", opponent)
-                continue
+            payload.update(opponent_payload)
             records.append(payload)
 
         if not records:
@@ -457,6 +442,83 @@ class LiveContextService:
             if col not in frame.columns:
                 frame[col] = pd.NA
         return frame
+
+    def _primary_payload_for_opponent(
+        self,
+        opponent: str,
+        year: int,
+        target_day: pd.Timestamp,
+    ) -> dict[str, Any] | None:
+        """Fetch and normalize one opponent's same-day schedule payload."""
+
+        try:
+            schedule = self._load_schedule_for_team(year, opponent)
+            if schedule is not None and not schedule.empty:
+                schedule = schedule.copy()
+                if "Date" not in schedule.columns:
+                    return None
+                schedule["game_date"] = schedule["Date"].map(
+                    lambda value: _coerce_schedule_date(value, year)
+                )
+                same_day = schedule[schedule["game_date"].dt.normalize() == target_day]
+                if same_day.empty:
+                    return None
+                weather_row = same_day.iloc[0].to_dict()
+                wind_speed, wind_direction = _extract_wind_components(
+                    weather_row.get("Wind")
+                )
+                weather = normalize_weather_payload(
+                    {
+                        "game_temp_f": weather_row.get("Temp")
+                        or weather_row.get("temperature"),
+                        "wind_speed_mph": wind_speed
+                        or weather_row.get("wind_speed_mph"),
+                        "humidity_pct": weather_row.get("Humidity")
+                        or weather_row.get("humidity_pct"),
+                        "wind_direction": weather_row.get("WindDir")
+                        or wind_direction
+                        or weather_row.get("wind_direction"),
+                    },
+                    use_defaults=False,
+                )
+            else:
+                weather = normalize_weather_payload({}, use_defaults=False)
+
+            payload = normalize_venue_payload({"roof_state": None})
+            payload.update(weather)
+            weather_values = [
+                payload.get("game_temp_f"),
+                payload.get("humidity_pct"),
+                payload.get("wind_speed_mph"),
+            ]
+            payload["weather_known_flag"] = int(
+                all(pd.notna(value) for value in weather_values)
+            )
+            return payload
+        except Exception:
+            logger.debug("Primary live feature fetch failed for team=%s", opponent)
+            return None
+
+    def _load_schedule_for_team(self, year: int, opponent: str) -> pd.DataFrame | None:
+        """Return cached or freshly fetched schedule data for one team/year."""
+
+        cache_key = (year, opponent)
+        with self._schedule_cache_lock:
+            if cache_key in self._schedule_cache:
+                cached = self._schedule_cache[cache_key]
+                return None if cached is None else cached.copy()
+
+        fetched: pd.DataFrame | None = None
+        schedule = schedule_and_record(year, opponent)
+        if schedule is not None and not schedule.empty:
+            fetched = schedule.copy()
+
+        with self._schedule_cache_lock:
+            self._schedule_cache[cache_key] = (
+                None if fetched is None else fetched.copy()
+            )
+
+        return None if fetched is None else fetched.copy()
 
     def _fetch_secondary(
         self, rows: pd.DataFrame, target_date: datetime

--- a/src/mlb/pitcher_props/__init__.py
+++ b/src/mlb/pitcher_props/__init__.py
@@ -2,5 +2,14 @@
 
 from src.mlb.pitcher_props.adapter import MlbPitcherPropsPipeline
 from src.mlb.pitcher_props.pipeline import run_mlb_pitcher_prop_pipeline
+from src.mlb.pitcher_props.slate import (
+    MlbPitcherPropSlateResult,
+    run_mlb_pitcher_prop_slate,
+)
 
-__all__ = ["MlbPitcherPropsPipeline", "run_mlb_pitcher_prop_pipeline"]
+__all__ = [
+    "MlbPitcherPropSlateResult",
+    "MlbPitcherPropsPipeline",
+    "run_mlb_pitcher_prop_pipeline",
+    "run_mlb_pitcher_prop_slate",
+]

--- a/src/mlb/pitcher_props/data.py
+++ b/src/mlb/pitcher_props/data.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from src.mlb.features import aggregate_pitcher_games
+from src.utils.names import from_last_first
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +262,40 @@ def build_pitcher_game_table(
 
     if "game_date" in games.columns:
         games["game_date"] = pd.to_datetime(games["game_date"], errors="coerce")
+    if "pitcher" in games.columns and "pitcher_id" not in games.columns:
+        games["pitcher_id"] = pd.to_numeric(games["pitcher"], errors="coerce").fillna(
+            games["pitcher"]
+        )
+
+    if {"pitcher", "game_date", "player_name"}.issubset(source.columns):
+        pitcher_identity = (
+            source[["pitcher", "game_date", "player_name"]]
+            .dropna(subset=["pitcher", "game_date", "player_name"])
+            .copy()
+        )
+        pitcher_identity["game_date"] = pd.to_datetime(
+            pitcher_identity["game_date"], errors="coerce"
+        )
+        pitcher_identity["pitcher_name"] = pitcher_identity["player_name"].map(
+            from_last_first
+        )
+        pitcher_identity = pitcher_identity.loc[
+            pitcher_identity["pitcher_name"].astype(str).str.strip() != ""
+        ]
+        pitcher_identity = pitcher_identity.drop_duplicates(
+            subset=["pitcher", "game_date"], keep="first"
+        )[["pitcher", "game_date", "pitcher_name"]]
+        games = games.merge(
+            pitcher_identity,
+            on=["pitcher", "game_date"],
+            how="left",
+        )
+
+    if "pitcher_name" not in games.columns:
+        games["pitcher_name"] = pd.NA
+    games["pitcher_name"] = games["pitcher_name"].fillna(
+        games["pitcher_id"].astype(str)
+    )
 
     required_pitch_cols = {"events", "pitcher", "game_date"}
     if not required_pitch_cols.issubset(source.columns):
@@ -303,6 +338,24 @@ def build_pitcher_game_table(
         .sum(min_count=1)
         .rename(columns={"runs_allowed_play": "earned_runs"})
     )
+    if "inning" in source.columns:
+        starter_flags = (
+            source.groupby(["pitcher", "game_date"], as_index=False)["inning"]
+            .min()
+            .rename(columns={"inning": "first_inning"})
+        )
+        starter_flags["is_starter"] = (
+            pd.to_numeric(starter_flags["first_inning"], errors="coerce")
+            .eq(1)
+            .astype(int)
+        )
+        grouped = grouped.merge(
+            starter_flags[["pitcher", "game_date", "is_starter"]],
+            on=["pitcher", "game_date"],
+            how="left",
+        )
+    else:
+        grouped["is_starter"] = 0
 
     if "launch_speed" in source.columns:
         contact = source[source["launch_speed"].notna()].copy()
@@ -322,6 +375,11 @@ def build_pitcher_game_table(
             )
 
     games = games.merge(grouped, on=["pitcher", "game_date"], how="left")
+    if "is_starter" not in games.columns:
+        games["is_starter"] = 0
+    games["is_starter"] = (
+        pd.to_numeric(games["is_starter"], errors="coerce").fillna(0).astype(int)
+    )
 
     high_fidelity = _normalize_earned_runs_source_frame(
         earned_runs_source if earned_runs_source is not None else pd.DataFrame()

--- a/src/mlb/pitcher_props/live_lines.py
+++ b/src/mlb/pitcher_props/live_lines.py
@@ -9,7 +9,11 @@ from pathlib import Path
 import pandas as pd
 
 from src.mlb.data.load_props import normalize_pitcher_prop_lines
-from src.mlb.pitcher_props.descriptors import StatDescriptor, get_stat_descriptor
+from src.mlb.pitcher_props.descriptors import (
+    STAT_DESCRIPTORS,
+    StatDescriptor,
+    get_stat_descriptor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +108,10 @@ def normalize_live_pitcher_prop_lines(
     work = live_lines.copy()
 
     if "stat_id" in work.columns:
-        work = work.loc[work["stat_id"].astype(str) == descriptor.stat].copy()
+        stat_ids = work["stat_id"].astype(str)
+        canonical_stats = set(STAT_DESCRIPTORS)
+        if set(stat_ids) & canonical_stats:
+            work = work.loc[stat_ids == descriptor.stat].copy()
 
     if work.empty:
         return _empty_live_line_frame(descriptor)

--- a/src/mlb/pitcher_props/live_lines.py
+++ b/src/mlb/pitcher_props/live_lines.py
@@ -1,0 +1,203 @@
+"""Helpers for normalizing live MLB pitcher prop lines and writing snapshots."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from pathlib import Path
+
+import pandas as pd
+
+from src.mlb.data.load_props import normalize_pitcher_prop_lines
+from src.mlb.pitcher_props.descriptors import StatDescriptor, get_stat_descriptor
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_COLUMNS: tuple[str, ...] = (
+    "appearance_id",
+    "player_ud_id",
+    "player_name",
+    "game_id",
+    "team_id",
+    "scheduled_at",
+    "season_type",
+    "stat_id",
+    "book",
+    "line",
+    "over_decimal_price",
+    "over_payout_multiplier",
+    "over_american_price",
+    "under_decimal_price",
+    "under_payout_multiplier",
+    "under_american_price",
+)
+
+_SORT_COLUMNS: tuple[str, ...] = ("game_id", "appearance_id", "scheduled_at")
+
+
+def _snapshot_date_string(snapshot_date: date | datetime | pd.Timestamp | str) -> str:
+    """Return a deterministic ISO date string for a snapshot filename."""
+
+    timestamp = pd.Timestamp(snapshot_date)
+    if pd.isna(timestamp):
+        raise ValueError("snapshot_date must be a valid date or timestamp.")
+    return timestamp.date().isoformat()
+
+
+def _empty_live_line_frame(descriptor: StatDescriptor) -> pd.DataFrame:
+    """Return an empty canonical live-line frame for a stat descriptor."""
+
+    columns = [
+        "appearance_id",
+        "player_ud_id",
+        "player",
+        "player_name",
+        "game_id",
+        "team_id",
+        "scheduled_at",
+        "season_type",
+        "stat_id",
+        "book",
+        descriptor.line_col,
+        "over_decimal_price",
+        "over_payout_multiplier",
+        "over_american_price",
+        "under_decimal_price",
+        "under_payout_multiplier",
+        "under_american_price",
+    ]
+    return pd.DataFrame(columns=columns)
+
+
+def _clean_text_series(frame: pd.Series) -> pd.Series:
+    """Return a string series with blank values normalized to missing."""
+
+    cleaned = frame.astype("string").str.strip()
+    return cleaned.mask(cleaned.eq(""))
+
+
+def _require_columns(frame: pd.DataFrame, columns: tuple[str, ...]) -> None:
+    """Raise if a frame is missing required columns."""
+
+    missing = [column for column in columns if column not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"Live lines missing required columns for normalization: {missing}"
+        )
+
+
+def normalize_live_pitcher_prop_lines(
+    live_lines: pd.DataFrame,
+    stat: str,
+) -> pd.DataFrame:
+    """Normalize unified Underdog live rows into a stat-specific line frame.
+
+    Args:
+        live_lines: Unified live line rows from the Underdog ingestion helper.
+        stat: MLB pitcher-prop stat identifier.
+
+    Returns:
+        Canonical stat-specific line frame suitable for existing loaders.
+    """
+
+    descriptor = get_stat_descriptor(stat)
+    work = live_lines.copy()
+
+    if "stat_id" in work.columns:
+        work = work.loc[work["stat_id"].astype(str) == descriptor.stat].copy()
+
+    if work.empty:
+        return _empty_live_line_frame(descriptor)
+
+    _require_columns(work, _SORT_COLUMNS)
+
+    if "player" not in work.columns:
+        if "player_name" not in work.columns:
+            raise ValueError("Live lines require a player or player_name column.")
+        work["player"] = pd.NA
+    if "player_name" not in work.columns:
+        work["player_name"] = pd.NA
+
+    work["player"] = _clean_text_series(work["player"])
+    work["player_name"] = _clean_text_series(work["player_name"])
+    resolved_player = work["player_name"].combine_first(work["player"])
+    if resolved_player.isna().any():
+        raise ValueError(
+            "Live lines require a non-empty player_name or player value."
+        )
+    work["player"] = resolved_player
+    work["player_name"] = resolved_player
+
+    if descriptor.line_col not in work.columns:
+        if "line" not in work.columns:
+            raise ValueError("Live lines require a line column.")
+        work[descriptor.line_col] = work["line"]
+
+    work = work.drop(columns=["line"], errors="ignore")
+
+    work = work.sort_values(
+        ["player", "game_id", "appearance_id", "scheduled_at"],
+        kind="stable",
+    ).reset_index(drop=True)
+
+    work = normalize_pitcher_prop_lines(work, descriptor.line_col)
+
+    ordered_columns = [
+        "appearance_id",
+        "player_ud_id",
+        "player",
+        "player_name",
+        "game_id",
+        "team_id",
+        "scheduled_at",
+        "season_type",
+        "stat_id",
+        "book",
+        descriptor.line_col,
+        "over_decimal_price",
+        "over_payout_multiplier",
+        "over_american_price",
+        "under_decimal_price",
+        "under_payout_multiplier",
+        "under_american_price",
+    ]
+    for column in ordered_columns:
+        if column not in work.columns:
+            work[column] = pd.NA
+
+    return work.loc[:, ordered_columns].copy()
+
+
+def write_live_pitcher_prop_snapshot(
+    live_lines: pd.DataFrame,
+    stat: str,
+    *,
+    output_dir: str | Path,
+    snapshot_date: date | datetime | pd.Timestamp | str,
+) -> Path:
+    """Write a stat-specific live line snapshot to a dated CSV file.
+
+    Args:
+        live_lines: Unified live line rows from the Underdog ingestion helper.
+        stat: MLB pitcher-prop stat identifier.
+        output_dir: Directory where the dated snapshot should be written.
+        snapshot_date: Date used in the filename.
+
+    Returns:
+        Path to the written snapshot file.
+    """
+
+    descriptor = get_stat_descriptor(stat)
+    normalized = normalize_live_pitcher_prop_lines(live_lines, stat)
+    snapshot_dir = Path(output_dir)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = snapshot_dir / (
+        f"{descriptor.stat}_{_snapshot_date_string(snapshot_date)}.csv"
+    )
+    normalized.to_csv(snapshot_path, index=False)
+    logger.info(
+        "Wrote MLB live line snapshot for '%s' to %s",
+        descriptor.stat,
+        snapshot_path,
+    )
+    return snapshot_path

--- a/src/mlb/pitcher_props/pipeline.py
+++ b/src/mlb/pitcher_props/pipeline.py
@@ -332,6 +332,13 @@ def _build_training_games(
             batter_output_path=str(batter_out) if batter_out else None,
             earned_runs_source=earned_runs_source,
         )
+        if "is_starter" in games.columns:
+            games = games.loc[
+                pd.to_numeric(games["is_starter"], errors="coerce")
+                .fillna(0)
+                .astype(int)
+                .eq(1)
+            ].copy()
         games = add_rolling_features(games)
         games = _add_rolling_pressure_features(games)
         games = _add_opponent_tendency(

--- a/src/mlb/pitcher_props/slate.py
+++ b/src/mlb/pitcher_props/slate.py
@@ -1,0 +1,168 @@
+"""Unified MLB pitcher-prop slate orchestration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+
+import pandas as pd
+
+from src.core.contracts import PipelineConfig
+from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS
+from src.mlb.pitcher_props.pipeline import run_mlb_pitcher_prop_pipeline
+
+logger = logging.getLogger(__name__)
+
+_EMPTY_COMBINED_COLUMNS: tuple[str, ...] = (
+    "stat_id",
+    "player",
+    "predicted_value",
+    "prob_over",
+    "prob_under",
+    "ev_over",
+    "ev_under",
+    "run_mode",
+    "lines_status",
+)
+
+
+@dataclass(slots=True)
+class MlbPitcherPropSlateResult:
+    """Aggregated result from a multi-stat MLB pitcher-prop slate run."""
+
+    combined_frame: pd.DataFrame
+    completed_stats: tuple[str, ...]
+    skipped_stats: dict[str, str]
+    failed_stats: dict[str, str]
+
+
+def _supported_stats(stats: Iterable[str] | None = None) -> tuple[str, ...]:
+    """Return the stat order to evaluate for a slate run."""
+
+    if stats is None:
+        return tuple(STAT_DESCRIPTORS.keys())
+    return tuple(stat.strip().lower() for stat in stats)
+
+
+def _validate_requested_stats(stats: tuple[str, ...]) -> None:
+    """Raise if the requested stat list includes unsupported MLB stats."""
+
+    unsupported = sorted(stat for stat in stats if stat not in STAT_DESCRIPTORS)
+    if unsupported:
+        supported = ", ".join(sorted(STAT_DESCRIPTORS))
+        raise ValueError(
+            "Unsupported MLB pitcher-prop stat(s): "
+            f"{unsupported}. Supported stats: {supported}"
+        )
+
+
+def _tag_scored_frame(frame: pd.DataFrame, stat: str) -> pd.DataFrame:
+    """Return a copy of scored rows annotated with the stat identifier."""
+
+    tagged = frame.copy()
+    tagged["stat_id"] = stat
+    return tagged
+
+
+def _empty_combined_frame() -> pd.DataFrame:
+    """Return a stable empty frame for downstream slate consumers."""
+
+    return pd.DataFrame(columns=_EMPTY_COMBINED_COLUMNS)
+
+
+def _is_expected_missing_input_error(exc: FileNotFoundError) -> bool:
+    """Return whether a file error represents an expected missing input."""
+
+    message = str(exc).strip().lower()
+    return message.startswith("pitcher prop lines file not found:") or any(
+        token in message for token in ("missing live lines", "missing input")
+    )
+
+
+def run_mlb_pitcher_prop_slate(
+    stat_configs: Mapping[str, PipelineConfig | None],
+    *,
+    scorer: Callable[[PipelineConfig, bool], pd.DataFrame] = (
+        run_mlb_pitcher_prop_pipeline
+    ),
+    retrain: bool = False,
+    stats: Iterable[str] | None = None,
+) -> MlbPitcherPropSlateResult:
+    """Run a multi-stat MLB pitcher-prop slate and combine scored outputs.
+
+    Args:
+        stat_configs: Mapping of stat name to validated config, or ``None`` when
+            a stat should be skipped.
+        scorer: Callable used to score one stat configuration.
+        retrain: Whether each scorer should retrain its underlying model.
+        stats: Optional explicit stat order. Defaults to all supported stats.
+
+    Returns:
+        Aggregated slate result with combined scored rows and run summary.
+    """
+
+    requested_stats = _supported_stats(stats)
+    _validate_requested_stats(requested_stats)
+
+    completed_stats: list[str] = []
+    skipped_stats: dict[str, str] = {}
+    failed_stats: dict[str, str] = {}
+    scored_frames: list[pd.DataFrame] = []
+
+    for stat in requested_stats:
+        config = stat_configs.get(stat)
+        if config is None:
+            skipped_stats[stat] = "no config provided"
+            logger.debug(
+                "Skipping MLB pitcher-prop stat '%s': no config provided", stat
+            )
+            continue
+
+        if config.stat != stat:
+            failed_stats[stat] = f"config stat mismatch: {config.stat}"
+            logger.warning(
+                "Failed MLB pitcher-prop stat '%s': config stat mismatch (%s)",
+                stat,
+                config.stat,
+            )
+            continue
+
+        try:
+            scored = scorer(config, retrain=retrain)
+        except FileNotFoundError as exc:
+            if _is_expected_missing_input_error(exc):
+                skipped_stats[stat] = str(exc)
+                logger.debug("Skipping MLB pitcher-prop stat '%s': %s", stat, exc)
+                continue
+            failed_stats[stat] = str(exc)
+            logger.warning("Failed MLB pitcher-prop stat '%s': %s", stat, exc)
+            continue
+        except Exception as exc:  # pragma: no cover - exercised via regression test
+            failed_stats[stat] = str(exc)
+            logger.warning("Failed MLB pitcher-prop stat '%s': %s", stat, exc)
+            continue
+
+        if scored is None or scored.empty:
+            skipped_stats[stat] = "no scored frame returned"
+            logger.debug(
+                "Skipping MLB pitcher-prop stat '%s': no scored frame returned",
+                stat,
+            )
+            continue
+
+        completed_stats.append(stat)
+        scored_frames.append(_tag_scored_frame(scored, stat))
+
+    combined_frame = (
+        pd.concat(scored_frames, ignore_index=True, sort=False)
+        if scored_frames
+        else _empty_combined_frame()
+    )
+
+    return MlbPitcherPropSlateResult(
+        combined_frame=combined_frame,
+        completed_stats=tuple(completed_stats),
+        skipped_stats=skipped_stats,
+        failed_stats=failed_stats,
+    )

--- a/src/mlb/slip_report.py
+++ b/src/mlb/slip_report.py
@@ -1,0 +1,208 @@
+"""Human-readable formatting for saved MLB slip artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def _humanize_stat(stat_id: object) -> str:
+    """Return a human-readable stat label.
+
+    Args:
+        stat_id: Raw stat identifier from a slip leg.
+
+    Returns:
+        Printable stat label.
+    """
+
+    stat_text = str(stat_id or "").strip()
+    if not stat_text:
+        return "stat"
+    return stat_text.replace("_", " ")
+
+
+def _format_decimal(value: object, digits: int = 2) -> str:
+    """Return a compact decimal string for numeric values.
+
+    Args:
+        value: Value to format.
+        digits: Decimal precision before trimming trailing zeroes.
+
+    Returns:
+        Compact string representation or ``n/a`` when missing.
+    """
+
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return "n/a"
+    text = f"{float(numeric):.{digits}f}"
+    return text.rstrip("0").rstrip(".")
+
+
+def _format_percent(value: object) -> str:
+    """Return a percentage string for a probability value.
+
+    Args:
+        value: Probability in ``[0, 1]``.
+
+    Returns:
+        Percentage string or ``n/a`` when missing.
+    """
+
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return "n/a"
+    return f"{float(numeric) * 100:.1f}%"
+
+
+def _format_signed_decimal(value: object, digits: int = 2) -> str:
+    """Return a signed decimal string for numeric values.
+
+    Args:
+        value: Value to format.
+        digits: Decimal precision.
+
+    Returns:
+        Signed decimal string or ``n/a`` when missing.
+    """
+
+    numeric = pd.to_numeric([value], errors="coerce")[0]
+    if pd.isna(numeric):
+        return "n/a"
+    return f"{float(numeric):+.{digits}f}"
+
+
+def _predicted_value_for_leg(leg: dict[str, Any]) -> object:
+    """Return the best available model prediction for a slip leg.
+
+    Args:
+        leg: Slip leg payload.
+
+    Returns:
+        Matching prediction value when available.
+    """
+
+    prediction_column = (
+        f"predicted_{str(leg.get('stat_id', '')).strip().lower()}" if leg else ""
+    )
+    if prediction_column and prediction_column in leg:
+        return leg.get(prediction_column)
+    return leg.get("predicted_value")
+
+
+def _format_leg_line(leg: dict[str, Any], index: int) -> str:
+    """Return a single human-readable line for a slip leg.
+
+    Args:
+        leg: Slip leg payload.
+        index: 1-based leg index within the slip.
+
+    Returns:
+        Rendered human-readable leg line.
+    """
+
+    player = str(leg.get("player") or leg.get("pitcher_name") or "Unknown player")
+    team = str(leg.get("team") or leg.get("pitcher_team") or "?")
+    opponent = str(leg.get("opponent") or leg.get("upcoming_opponent") or "?")
+    stat = _humanize_stat(leg.get("stat_id") or leg.get("market"))
+    play = str(leg.get("play") or "").lower()
+    line = _format_decimal(leg.get("line"), digits=1)
+    predicted = _format_decimal(_predicted_value_for_leg(leg))
+    prob = _format_percent(leg.get("prob"))
+    ev = _format_signed_decimal(leg.get("ev"))
+    return (
+        f"{index}. {player} ({team}) vs {opponent}: {stat} {play} {line} "
+        f"[model {predicted}, win {prob}, ev {ev}]"
+    )
+
+
+def render_slip_payloads(slip_payloads: dict[str, list[dict[str, Any]]]) -> str:
+    """Return a human-readable report for grouped slip payloads.
+
+    Args:
+        slip_payloads: Mapping of slip tags to slip lists.
+
+    Returns:
+        Multi-line human-readable report.
+    """
+
+    lines: list[str] = []
+    for tag, slips in slip_payloads.items():
+        lines.append(f"{tag.upper()} SLIPS")
+        if not slips:
+            lines.append("None.")
+            lines.append("")
+            continue
+
+        for slip_index, slip in enumerate(slips, start=1):
+            lines.append(
+                " | ".join(
+                    [
+                        f"Slip {slip_index}",
+                        f"{int(slip.get('slip_size', len(slip.get('legs', []))))} legs",
+                        f"units {slip.get('units', 1)}",
+                        f"win {_format_percent(slip.get('p_win'))}",
+                        f"total ev {_format_signed_decimal(slip.get('total_ev'))}",
+                    ]
+                )
+            )
+            for leg_index, leg in enumerate(slip.get("legs", []), start=1):
+                lines.append(_format_leg_line(leg, leg_index))
+            lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def render_slip_report(
+    summary: dict[str, Any], tags: tuple[str, ...] | None = None
+) -> str:
+    """Return a human-readable report for saved slip files in a summary.
+
+    Args:
+        summary: Summary artifact containing ``slip_files``.
+        tags: Optional subset of slip tags to print.
+
+    Returns:
+        Multi-line human-readable report.
+
+    Raises:
+        ValueError: If the summary does not contain requested slip files.
+        FileNotFoundError: If a referenced slip artifact is missing.
+    """
+
+    slip_files = summary.get("slip_files")
+    if not isinstance(slip_files, dict) or not slip_files:
+        raise ValueError("Summary file does not contain any slip_files entries.")
+
+    requested_tags = tags or tuple(slip_files.keys())
+    slip_payloads: dict[str, list[dict[str, Any]]] = {}
+    for tag in requested_tags:
+        if tag not in slip_files:
+            raise ValueError(f"Requested slip tag '{tag}' not found in summary.")
+        path = Path(str(slip_files[tag]))
+        if not path.exists():
+            raise FileNotFoundError(f"Slip artifact not found: {path}")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        slips = payload.get("slips")
+        if not isinstance(slips, list):
+            raise ValueError(f"Slip artifact {path} does not contain a 'slips' list.")
+        slip_payloads[tag] = slips
+
+    return render_slip_payloads(slip_payloads)
+
+
+def load_summary(summary_path: Path) -> dict[str, Any]:
+    """Load a summary artifact from disk.
+
+    Args:
+        summary_path: Path to a summary JSON file.
+
+    Returns:
+        Parsed JSON payload.
+    """
+
+    return json.loads(summary_path.read_text(encoding="utf-8"))

--- a/src/mlb/slips.py
+++ b/src/mlb/slips.py
@@ -9,6 +9,56 @@ from itertools import combinations
 import numpy as np
 import pandas as pd
 
+_CANDIDATE_COLUMNS: tuple[str, ...] = (
+    "player",
+    "player_id",
+    "team",
+    "opponent",
+    "game_date",
+    "rest_days",
+    "park_factor",
+    "stat_id",
+    "line",
+    "play",
+    "prob",
+    "ev",
+    "payout",
+    "payout_multiplier",
+    "american_price",
+    "sport",
+    "market",
+)
+
+_SCORER_METADATA_COLUMNS: tuple[str, ...] = (
+    "predicted_value",
+    "predicted_strikeouts",
+    "predicted_outs_recorded",
+    "predicted_earned_runs",
+    "predicted_hits_allowed",
+    "predicted_bb_allowed",
+    "model_residual_std",
+    "run_mode",
+    "lines_status",
+    "simulation_mean",
+    "simulation_std",
+    "simulation_median",
+    "model_name",
+    "model_strategy",
+)
+
+_LEGACY_REQUIRED_COLUMNS: tuple[str, ...] = (
+    "player",
+    "pitcher_id",
+    "pitcher_team",
+    "k_line",
+    "prob_over",
+    "prob_under",
+    "ev_over",
+    "ev_under",
+    "over_decimal_price",
+    "under_decimal_price",
+)
+
 
 @dataclass
 class SlipBuilderConfig:
@@ -26,70 +76,145 @@ class SlipBuilderConfig:
             self.payout_table = {2: 3, 3: 6, 4: 10, 5: 20, 6: 35, 7: 65, 8: 120}
 
 
+def _empty_candidate_frame() -> pd.DataFrame:
+    """Return an empty generic candidate-leg frame."""
+
+    return pd.DataFrame(columns=_CANDIDATE_COLUMNS)
+
+
+def _has_candidate_leg_schema(df: pd.DataFrame) -> bool:
+    """Return whether a frame already contains candidate-leg columns."""
+
+    return {"play", "prob", "ev", "payout"}.issubset(df.columns)
+
+
+def _standardize_candidate_frame(
+    results: pd.DataFrame,
+    *,
+    top_n: int | None = None,
+    min_ev: float = 0.0,
+) -> pd.DataFrame:
+    """Normalize either legacy or candidate-leg rows into a shared schema."""
+
+    if results is None or results.empty:
+        return _empty_candidate_frame()
+
+    df = results.copy()
+    if _has_candidate_leg_schema(df):
+        if "player" not in df.columns and "pitcher_name" in df.columns:
+            df["player"] = df["pitcher_name"]
+        if "player_id" not in df.columns and "pitcher_id" in df.columns:
+            df["player_id"] = df["pitcher_id"]
+        if "team" not in df.columns and "pitcher_team" in df.columns:
+            df["team"] = df["pitcher_team"]
+        if "line" not in df.columns and "k_line" in df.columns:
+            df["line"] = df["k_line"]
+        if "stat_id" not in df.columns:
+            if "market" in df.columns:
+                df["stat_id"] = df["market"]
+            else:
+                df["stat_id"] = "strikeouts"
+        if "sport" not in df.columns:
+            df["sport"] = "MLB"
+        if "market" not in df.columns:
+            df["market"] = df["stat_id"]
+    else:
+        missing = set(_LEGACY_REQUIRED_COLUMNS) - set(df.columns)
+        if missing:
+            raise ValueError(
+                f"Results DataFrame missing required columns: {sorted(missing)}"
+            )
+
+        over = df.copy()
+        over = over.assign(
+            player=df["player"],
+            player_id=df["pitcher_id"],
+            team=df["pitcher_team"],
+            opponent=df.get("upcoming_opponent"),
+            game_date=df.get("upcoming_game_date"),
+            rest_days=df.get("upcoming_rest_days"),
+            park_factor=df.get("upcoming_park_factor_K"),
+            play="over",
+            prob=df["prob_over"],
+            ev=df["ev_over"],
+            payout=df["over_decimal_price"],
+            payout_multiplier=df.get("over_payout_multiplier"),
+            american_price=df.get("over_american_price"),
+            line=df["k_line"],
+            stat_id="strikeouts",
+            sport="MLB",
+            market="strikeouts",
+        )
+
+        under = df.copy()
+        under = under.assign(
+            player=df["player"],
+            player_id=df["pitcher_id"],
+            team=df["pitcher_team"],
+            opponent=df.get("upcoming_opponent"),
+            game_date=df.get("upcoming_game_date"),
+            rest_days=df.get("upcoming_rest_days"),
+            park_factor=df.get("upcoming_park_factor_K"),
+            play="under",
+            prob=df["prob_under"],
+            ev=df["ev_under"],
+            payout=df["under_decimal_price"],
+            payout_multiplier=df.get("under_payout_multiplier"),
+            american_price=df.get("under_american_price"),
+            line=df["k_line"],
+            stat_id="strikeouts",
+            sport="MLB",
+            market="strikeouts",
+        )
+
+        for frame in (over, under):
+            if "pitcher_name" not in frame.columns:
+                frame["pitcher_name"] = frame["player"]
+            if "pitcher_id" not in frame.columns:
+                frame["pitcher_id"] = frame["player_id"]
+            if "pitcher_team" not in frame.columns:
+                frame["pitcher_team"] = frame["team"]
+            if "k_line" not in frame.columns:
+                frame["k_line"] = frame["line"]
+
+        df = pd.concat([over, under], ignore_index=True)
+
+    df = df.loc[df["ev"] > min_ev].copy()
+    df = df.sort_values("ev", ascending=False).reset_index(drop=True)
+
+    if top_n is not None:
+        df = df.head(top_n).copy()
+
+    for column in _CANDIDATE_COLUMNS:
+        if column not in df.columns:
+            df[column] = pd.NA
+
+    if "game_date" in df.columns:
+        df["game_date"] = pd.to_datetime(df["game_date"], errors="coerce")
+
+    base_columns = list(_CANDIDATE_COLUMNS)
+    passthrough_columns = [
+        column
+        for column in df.columns
+        if column not in base_columns and column not in _SCORER_METADATA_COLUMNS
+    ]
+    selected_columns = (
+        base_columns + list(_SCORER_METADATA_COLUMNS) + passthrough_columns
+    )
+
+    for column in selected_columns:
+        if column not in df.columns:
+            df[column] = pd.NA
+
+    return df.loc[:, selected_columns].copy()
+
+
 def prepare_long_df(
     results: pd.DataFrame, *, top_n: int | None = None, min_ev: float = 0.0
 ) -> pd.DataFrame:
     """Create an over/under long-form DataFrame sorted by leg EV."""
 
-    df = results.copy()
-    required_cols = {
-        "player",
-        "pitcher_id",
-        "pitcher_team",
-        "k_line",
-        "prob_over",
-        "prob_under",
-        "ev_over",
-        "ev_under",
-        "over_decimal_price",
-        "under_decimal_price",
-    }
-    missing = required_cols - set(df.columns)
-    if missing:
-        raise ValueError(
-            f"Results DataFrame missing required columns: {sorted(missing)}"
-        )
-
-    base_cols = [
-        "player",
-        "pitcher_id",
-        "pitcher_team",
-        "k_line",
-        "upcoming_opponent",
-        "upcoming_game_date",
-        "upcoming_rest_days",
-        "upcoming_park_factor_K",
-    ]
-
-    over = df.copy()
-    over = over.assign(
-        play="over",
-        prob=df["prob_over"],
-        ev=df["ev_over"],
-        payout=df["over_decimal_price"],
-    )
-
-    under = df.copy()
-    under = under.assign(
-        play="under",
-        prob=df["prob_under"],
-        ev=df["ev_under"],
-        payout=df["under_decimal_price"],
-    )
-
-    combined = pd.concat([over, under], ignore_index=True)
-    combined = combined.loc[combined["ev"] > min_ev].copy()
-    combined = combined.sort_values("ev", ascending=False)
-    combined = combined.reset_index(drop=True)
-
-    columns = base_cols + ["play", "prob", "ev", "payout"]
-    combined = combined[columns]
-    combined.rename(columns={"player": "pitcher_name"}, inplace=True)
-
-    if top_n is not None:
-        combined = combined.head(top_n)
-
-    return combined
+    return _standardize_candidate_frame(results, top_n=top_n, min_ev=min_ev)
 
 
 def _clean_value(value):
@@ -106,6 +231,54 @@ def _clean_value(value):
     return value
 
 
+def _coalesce(*values):
+    """Return the first non-null, non-empty value from a sequence."""
+
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        if pd.isna(value):
+            continue
+        return value
+    return None
+
+
+def _candidate_identity(leg: dict) -> tuple[str, str, str]:
+    """Return the identity tuple used to deduplicate slip combinations."""
+
+    player = leg.get("player") or leg.get("pitcher") or leg.get("pitcher_name")
+    stat_id = leg.get("stat_id") or leg.get("market") or leg.get("line")
+    play = leg.get("play")
+    return (str(player), str(stat_id), str(play))
+
+
+def _player_count(combo: tuple[object, ...]) -> int:
+    """Return the number of distinct players in a candidate combo."""
+
+    players = set()
+    for row in combo:
+        player = _coalesce(
+            getattr(row, "player", None),
+            getattr(row, "pitcher_name", None),
+        )
+        if player is not None:
+            players.add(str(player))
+    return len(players)
+
+
+def _team_count(combo: tuple[object, ...]) -> int:
+    """Return the number of distinct teams in a candidate combo."""
+
+    teams = set()
+    for row in combo:
+        team = _coalesce(getattr(row, "team", None), getattr(row, "pitcher_team", None))
+        if team is not None:
+            teams.add(str(team))
+    return len(teams)
+
+
 def generate_slips(
     df: pd.DataFrame, slip_size: int, payout_table: dict[int, float]
 ) -> list[dict]:
@@ -116,9 +289,10 @@ def generate_slips(
     if not payout:
         return slips
 
-    for combo in combinations(df.itertuples(index=False), slip_size):
-        pitcher_names = {x.pitcher_name for x in combo}
-        if len(pitcher_names) < slip_size:
+    normalized = _standardize_candidate_frame(df, min_ev=float("-inf"))
+
+    for combo in combinations(normalized.itertuples(index=False), slip_size):
+        if _player_count(combo) < 2 or _team_count(combo) < 2:
             continue
 
         probs = [float(x.prob) for x in combo]
@@ -130,19 +304,70 @@ def generate_slips(
 
         legs = []
         for x in combo:
+            player = _coalesce(
+                getattr(x, "player", None),
+                getattr(x, "pitcher_name", None),
+            )
+            team = _coalesce(
+                getattr(x, "team", None),
+                getattr(x, "pitcher_team", None),
+            )
+            stat_id = _coalesce(
+                getattr(x, "stat_id", None),
+                getattr(x, "market", None),
+            )
+            player_id = _coalesce(
+                getattr(x, "player_id", None), getattr(x, "pitcher_id", None)
+            )
+            market = _coalesce(getattr(x, "market", None), stat_id)
+            line_value = _coalesce(getattr(x, "line", None), getattr(x, "k_line", None))
+            opponent = _coalesce(
+                getattr(x, "opponent", None),
+                getattr(x, "upcoming_opponent", None),
+            )
+            game_date = _coalesce(
+                getattr(x, "game_date", None),
+                getattr(x, "upcoming_game_date", None),
+            )
+            rest_days = _coalesce(
+                getattr(x, "rest_days", None),
+                getattr(x, "upcoming_rest_days", None),
+            )
+            park_factor = _coalesce(
+                getattr(x, "park_factor", None),
+                getattr(x, "upcoming_park_factor_K", None),
+            )
             leg = {
-                "pitcher": x.pitcher_name,
-                "pitcher_team": _clean_value(x.pitcher_team),
-                "opponent": _clean_value(x.upcoming_opponent),
-                "game_date": _clean_value(x.upcoming_game_date),
-                "rest_days": _clean_value(x.upcoming_rest_days),
-                "park_factor_K": _clean_value(x.upcoming_park_factor_K),
+                "player": _clean_value(player),
+                "player_id": _clean_value(player_id),
+                "team": _clean_value(team),
+                "opponent": _clean_value(opponent),
+                "game_date": _clean_value(game_date),
+                "rest_days": _clean_value(rest_days),
+                "park_factor": _clean_value(park_factor),
+                "sport": _clean_value(getattr(x, "sport", None)),
+                "market": _clean_value(market),
+                "stat_id": _clean_value(stat_id),
                 "play": x.play,
                 "prob": float(x.prob),
                 "ev": float(x.ev),
                 "payout": float(x.payout),
-                "k_line": float(x.k_line),
+                "payout_multiplier": _clean_value(
+                    getattr(x, "payout_multiplier", None)
+                ),
+                "american_price": _clean_value(getattr(x, "american_price", None)),
+                "line": _clean_value(line_value),
+                "pitcher": _clean_value(player),
+                "pitcher_name": _clean_value(player),
+                "pitcher_team": _clean_value(team),
+                "k_line": _clean_value(line_value),
             }
+            extra_fields = {
+                key: _clean_value(value)
+                for key, value in x._asdict().items()
+                if key not in leg
+            }
+            leg.update(extra_fields)
             legs.append(leg)
 
         slips.append(
@@ -166,7 +391,7 @@ def filter_diverse_slips(slips: Iterable[dict], max_shared_legs: int = 3) -> lis
     seen: list[set] = []
 
     for slip in slips:
-        leg_ids = {(leg["pitcher"], leg["play"]) for leg in slip["legs"]}
+        leg_ids = {_candidate_identity(leg) for leg in slip["legs"]}
         if any(len(leg_ids & s) > max_shared_legs for s in seen):
             continue
         seen.append(leg_ids)

--- a/src/mlb/slips.py
+++ b/src/mlb/slips.py
@@ -9,6 +9,8 @@ from itertools import combinations
 import numpy as np
 import pandas as pd
 
+from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS
+
 _CANDIDATE_COLUMNS: tuple[str, ...] = (
     "player",
     "player_id",
@@ -50,7 +52,6 @@ _LEGACY_REQUIRED_COLUMNS: tuple[str, ...] = (
     "player",
     "pitcher_id",
     "pitcher_team",
-    "k_line",
     "prob_over",
     "prob_under",
     "ev_over",
@@ -67,6 +68,7 @@ class SlipBuilderConfig:
     fullsend_count: int = 5
     fullsend_min_size: int = 3
     fullsend_max_size: int = 6
+    max_legs_per_player: int = 3
     max_shared_legs: int = 3
     min_leg_ev: float = 0.0
     payout_table: dict[int, float] = None
@@ -86,6 +88,44 @@ def _has_candidate_leg_schema(df: pd.DataFrame) -> bool:
     """Return whether a frame already contains candidate-leg columns."""
 
     return {"play", "prob", "ev", "payout"}.issubset(df.columns)
+
+
+def _resolve_legacy_stat_descriptor(df: pd.DataFrame) -> tuple[str, str, str]:
+    """Infer stat id, line column, and park-factor column for legacy rows."""
+
+    stat_id = "strikeouts"
+    if "stat_id" in df.columns:
+        stat_values = (
+            df["stat_id"].dropna().astype(str).str.strip().str.lower().unique().tolist()
+        )
+        if len(stat_values) == 1 and stat_values[0] in STAT_DESCRIPTORS:
+            stat_id = stat_values[0]
+
+    descriptor = STAT_DESCRIPTORS[stat_id]
+    return (
+        stat_id,
+        descriptor.line_col,
+        f"upcoming_{descriptor.park_factor_col}",
+    )
+
+
+def _legacy_stat_subframes(df: pd.DataFrame) -> list[tuple[str, pd.DataFrame]]:
+    """Split legacy scorer rows into stat-specific frames."""
+
+    if "stat_id" not in df.columns:
+        return [("strikeouts", df.copy())]
+
+    stat_values = (
+        df["stat_id"].fillna("strikeouts").astype(str).str.strip().str.lower()
+    )
+    work = df.copy()
+    work["stat_id"] = stat_values
+
+    frames: list[tuple[str, pd.DataFrame]] = []
+    for stat_id, group in work.groupby("stat_id", sort=False, dropna=False):
+        resolved = stat_id if stat_id in STAT_DESCRIPTORS else "strikeouts"
+        frames.append((resolved, group.copy()))
+    return frames
 
 
 def _standardize_candidate_frame(
@@ -119,65 +159,71 @@ def _standardize_candidate_frame(
         if "market" not in df.columns:
             df["market"] = df["stat_id"]
     else:
-        missing = set(_LEGACY_REQUIRED_COLUMNS) - set(df.columns)
-        if missing:
-            raise ValueError(
-                f"Results DataFrame missing required columns: {sorted(missing)}"
+        normalized_frames: list[pd.DataFrame] = []
+        for stat_id, subset in _legacy_stat_subframes(df):
+            _, line_col, park_factor_col = _resolve_legacy_stat_descriptor(subset)
+            required_columns = set(_LEGACY_REQUIRED_COLUMNS) | {line_col}
+            missing = required_columns - set(subset.columns)
+            if missing:
+                raise ValueError(
+                    f"Results DataFrame missing required columns: {sorted(missing)}"
+                )
+
+            over = subset.copy()
+            over = over.assign(
+                player=subset["player"],
+                player_id=subset["pitcher_id"],
+                team=subset["pitcher_team"],
+                opponent=subset.get("upcoming_opponent"),
+                game_date=subset.get("upcoming_game_date"),
+                rest_days=subset.get("upcoming_rest_days"),
+                park_factor=subset.get(park_factor_col),
+                play="over",
+                prob=subset["prob_over"],
+                ev=subset["ev_over"],
+                payout=subset["over_decimal_price"],
+                payout_multiplier=subset.get("over_payout_multiplier"),
+                american_price=subset.get("over_american_price"),
+                line=subset[line_col],
+                stat_id=stat_id,
+                sport="MLB",
+                market=stat_id,
             )
 
-        over = df.copy()
-        over = over.assign(
-            player=df["player"],
-            player_id=df["pitcher_id"],
-            team=df["pitcher_team"],
-            opponent=df.get("upcoming_opponent"),
-            game_date=df.get("upcoming_game_date"),
-            rest_days=df.get("upcoming_rest_days"),
-            park_factor=df.get("upcoming_park_factor_K"),
-            play="over",
-            prob=df["prob_over"],
-            ev=df["ev_over"],
-            payout=df["over_decimal_price"],
-            payout_multiplier=df.get("over_payout_multiplier"),
-            american_price=df.get("over_american_price"),
-            line=df["k_line"],
-            stat_id="strikeouts",
-            sport="MLB",
-            market="strikeouts",
-        )
+            under = subset.copy()
+            under = under.assign(
+                player=subset["player"],
+                player_id=subset["pitcher_id"],
+                team=subset["pitcher_team"],
+                opponent=subset.get("upcoming_opponent"),
+                game_date=subset.get("upcoming_game_date"),
+                rest_days=subset.get("upcoming_rest_days"),
+                park_factor=subset.get(park_factor_col),
+                play="under",
+                prob=subset["prob_under"],
+                ev=subset["ev_under"],
+                payout=subset["under_decimal_price"],
+                payout_multiplier=subset.get("under_payout_multiplier"),
+                american_price=subset.get("under_american_price"),
+                line=subset[line_col],
+                stat_id=stat_id,
+                sport="MLB",
+                market=stat_id,
+            )
 
-        under = df.copy()
-        under = under.assign(
-            player=df["player"],
-            player_id=df["pitcher_id"],
-            team=df["pitcher_team"],
-            opponent=df.get("upcoming_opponent"),
-            game_date=df.get("upcoming_game_date"),
-            rest_days=df.get("upcoming_rest_days"),
-            park_factor=df.get("upcoming_park_factor_K"),
-            play="under",
-            prob=df["prob_under"],
-            ev=df["ev_under"],
-            payout=df["under_decimal_price"],
-            payout_multiplier=df.get("under_payout_multiplier"),
-            american_price=df.get("under_american_price"),
-            line=df["k_line"],
-            stat_id="strikeouts",
-            sport="MLB",
-            market="strikeouts",
-        )
+            for frame in (over, under):
+                if "pitcher_name" not in frame.columns:
+                    frame["pitcher_name"] = frame["player"]
+                if "pitcher_id" not in frame.columns:
+                    frame["pitcher_id"] = frame["player_id"]
+                if "pitcher_team" not in frame.columns:
+                    frame["pitcher_team"] = frame["team"]
+                if "k_line" not in frame.columns:
+                    frame["k_line"] = frame["line"]
 
-        for frame in (over, under):
-            if "pitcher_name" not in frame.columns:
-                frame["pitcher_name"] = frame["player"]
-            if "pitcher_id" not in frame.columns:
-                frame["pitcher_id"] = frame["player_id"]
-            if "pitcher_team" not in frame.columns:
-                frame["pitcher_team"] = frame["team"]
-            if "k_line" not in frame.columns:
-                frame["k_line"] = frame["line"]
+            normalized_frames.extend([over, under])
 
-        df = pd.concat([over, under], ignore_index=True)
+        df = pd.concat(normalized_frames, ignore_index=True)
 
     df = df.loc[df["ev"] > min_ev].copy()
     df = df.sort_values("ev", ascending=False).reset_index(drop=True)
@@ -279,8 +325,28 @@ def _team_count(combo: tuple[object, ...]) -> int:
     return len(teams)
 
 
+def _max_legs_for_any_player(combo: tuple[object, ...]) -> int:
+    """Return the largest number of legs assigned to any one player."""
+
+    counts: dict[str, int] = {}
+    for row in combo:
+        player = _coalesce(
+            getattr(row, "player", None),
+            getattr(row, "pitcher_name", None),
+        )
+        if player is None:
+            continue
+        player_key = str(player)
+        counts[player_key] = counts.get(player_key, 0) + 1
+    return max(counts.values(), default=0)
+
+
 def generate_slips(
-    df: pd.DataFrame, slip_size: int, payout_table: dict[int, float]
+    df: pd.DataFrame,
+    slip_size: int,
+    payout_table: dict[int, float],
+    *,
+    max_legs_per_player: int = 3,
 ) -> list[dict]:
     """Generate slip combinations of a given size from candidate legs."""
 
@@ -293,6 +359,8 @@ def generate_slips(
 
     for combo in combinations(normalized.itertuples(index=False), slip_size):
         if _player_count(combo) < 2 or _team_count(combo) < 2:
+            continue
+        if _max_legs_for_any_player(combo) > max_legs_per_player:
             continue
 
         probs = [float(x.prob) for x in combo]
@@ -414,7 +482,10 @@ def build_slip_sets(
     )
 
     conservative_candidates = generate_slips(
-        long_df, slip_size=2, payout_table=cfg.payout_table
+        long_df,
+        slip_size=2,
+        payout_table=cfg.payout_table,
+        max_legs_per_player=cfg.max_legs_per_player,
     )
     conservative_ranked = sorted(
         conservative_candidates, key=lambda x: x["total_ev"], reverse=True
@@ -429,7 +500,12 @@ def build_slip_sets(
     for size in range(cfg.fullsend_min_size, cfg.fullsend_max_size + 1):
         if len(long_df) >= size:
             fullsend_candidates.extend(
-                generate_slips(long_df, slip_size=size, payout_table=cfg.payout_table)
+                generate_slips(
+                    long_df,
+                    slip_size=size,
+                    payout_table=cfg.payout_table,
+                    max_legs_per_player=cfg.max_legs_per_player,
+                )
             )
     fullsend_ranked = sorted(
         fullsend_candidates, key=lambda x: x["total_ev"], reverse=True

--- a/tests/test_build_mlb_live_betslips.py
+++ b/tests/test_build_mlb_live_betslips.py
@@ -1,0 +1,349 @@
+"""CLI tests for MLB live Underdog shadow-run bet slips."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from src.core.config import ConfigValidationError
+from src.core.contracts import PipelineConfig
+from src.mlb.pitcher_props.slate import MlbPitcherPropSlateResult
+
+
+def _live_rows(stat: str, player: str, team: str) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "appearance_id": f"{stat}-appearance",
+                "player_ud_id": f"{stat}-player",
+                "player_name": player,
+                "game_id": f"{stat}-game",
+                "team_id": team,
+                "line": 7.5,
+                "book": "Underdog",
+                "scheduled_at": "2026-03-25T19:05:00Z",
+                "season_type": "regular",
+                "stat_id": stat,
+                "over_decimal_price": 1.92,
+                "over_payout_multiplier": 0.92,
+                "over_american_price": -110,
+                "under_decimal_price": 1.88,
+                "under_payout_multiplier": 0.88,
+                "under_american_price": -115,
+            }
+        ]
+    )
+
+
+def _slate_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "player": "Gerrit Cole",
+                "player_id": "cole-1",
+                "team": "NYY",
+                "opponent": "BOS",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 4,
+                "park_factor": 1.02,
+                "stat_id": "strikeouts",
+                "line": 8.5,
+                "play": "over",
+                "prob": 0.62,
+                "ev": 0.16,
+                "payout": 1.92,
+                "payout_multiplier": 0.92,
+                "sport": "MLB",
+                "market": "strikeouts",
+                "run_mode": "prediction",
+                "lines_status": "present",
+            },
+            {
+                "player": "Gerrit Cole",
+                "player_id": "cole-1",
+                "team": "NYY",
+                "opponent": "BOS",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 4,
+                "park_factor": 1.02,
+                "stat_id": "outs_recorded",
+                "line": 18.5,
+                "play": "over",
+                "prob": 0.58,
+                "ev": 0.11,
+                "payout": 1.9,
+                "payout_multiplier": 0.9,
+                "sport": "MLB",
+                "market": "outs_recorded",
+                "run_mode": "prediction",
+                "lines_status": "present",
+            },
+            {
+                "player": "Aaron Nola",
+                "player_id": "nola-1",
+                "team": "PHI",
+                "opponent": "ATL",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 5,
+                "park_factor": 0.97,
+                "stat_id": "hits_allowed",
+                "line": 6.5,
+                "play": "under",
+                "prob": 0.57,
+                "ev": 0.13,
+                "payout": 2.05,
+                "payout_multiplier": 1.05,
+                "sport": "MLB",
+                "market": "hits_allowed",
+                "run_mode": "prediction",
+                "lines_status": "present",
+            },
+        ]
+    )
+
+
+def _config(stat: str) -> PipelineConfig:
+    return PipelineConfig(
+        config_path=Path("config/mlb.yaml"),
+        sport="mlb",
+        stat=stat,
+        raw={"pipeline": {"sport": "mlb", "stat": stat}},
+        section={
+            "pitch_data_path": f"tests/{stat}_pitch.csv",
+            "model_path": f"tests/{stat}_model.joblib",
+            "lines_path": f"tests/{stat}_lines.csv",
+        },
+    )
+
+
+def test_build_mlb_live_betslips_writes_snapshots_and_json_slips(
+    monkeypatch: object, tmp_path: Path, capsys: object
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[
+            "strikeouts=PickemStat_strikeouts",
+            "outs_recorded=PickemStat_outs_recorded",
+            "hits_allowed=PickemStat_hits_allowed",
+        ],
+    )
+    monkeypatch.setattr(cli, "parse_args", lambda: args)
+
+    imported: list[str] = []
+
+    def fake_import_ud_mlb_lines(algolia_object_id: str) -> pd.DataFrame:
+        imported.append(algolia_object_id)
+        if algolia_object_id.endswith("strikeouts"):
+            return _live_rows("strikeouts", "Gerrit Cole", "team-home")
+        if algolia_object_id.endswith("outs_recorded"):
+            return _live_rows("outs_recorded", "Gerrit Cole", "team-home")
+        return _live_rows("hits_allowed", "Aaron Nola", "team-away")
+
+    monkeypatch.setattr(cli, "import_ud_mlb_lines", fake_import_ud_mlb_lines)
+
+    def fake_load_pipeline_config(
+        *_: object,
+        stat_override: str | None = None,
+        **__: object,
+    ) -> PipelineConfig:
+        return _config(stat_override or "")
+
+    monkeypatch.setattr(cli, "load_pipeline_config", fake_load_pipeline_config)
+
+    def fake_run_mlb_pitcher_prop_slate(
+        stat_configs: dict[str, PipelineConfig],
+        *,
+        retrain: bool = False,
+        stats: tuple[str, ...] | None = None,
+        scorer: object | None = None,
+    ) -> MlbPitcherPropSlateResult:
+        del retrain, stats, scorer
+        assert set(stat_configs) == {"strikeouts", "outs_recorded", "hits_allowed"}
+        return MlbPitcherPropSlateResult(
+            combined_frame=_slate_frame(),
+            completed_stats=("strikeouts", "outs_recorded", "hits_allowed"),
+            skipped_stats={},
+            failed_stats={},
+        )
+
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        fake_run_mlb_pitcher_prop_slate,
+    )
+
+    returned_summary = cli.main()
+    captured = capsys.readouterr()
+
+    assert imported == [
+        "PickemStat_strikeouts",
+        "PickemStat_outs_recorded",
+        "PickemStat_hits_allowed",
+    ]
+
+    assert (tmp_path / "lines" / "strikeouts_2026-03-25.csv").exists()
+    assert (tmp_path / "lines" / "outs_recorded_2026-03-25.csv").exists()
+    assert (tmp_path / "lines" / "hits_allowed_2026-03-25.csv").exists()
+
+    conservative_path = tmp_path / "betslips" / "mlb_live_2026-03-25_conservative.json"
+    fullsend_path = tmp_path / "betslips" / "mlb_live_2026-03-25_fullsend.json"
+    summary_path = tmp_path / "betslips" / "mlb_live_2026-03-25_summary.json"
+
+    assert conservative_path.exists()
+    assert fullsend_path.exists()
+    assert summary_path.exists()
+
+    conservative = json.loads(conservative_path.read_text())
+    fullsend = json.loads(fullsend_path.read_text())
+    assert conservative["slips"] == []
+    assert len(fullsend["slips"]) == 1
+    persisted_summary = json.loads(summary_path.read_text())
+    assert returned_summary["completed_stats"] == [
+        "strikeouts",
+        "outs_recorded",
+        "hits_allowed",
+    ]
+    assert returned_summary["combined_rows"] == 3
+    assert returned_summary["slip_counts"] == {"conservative": 0, "fullsend": 1}
+    assert returned_summary["summary_file"] == str(summary_path)
+    assert persisted_summary["summary_file"] == str(summary_path)
+    assert persisted_summary == returned_summary
+    assert "MLB live shadow run" in captured.out
+
+
+def test_build_mlb_live_betslips_continues_after_stat_level_failures(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[
+            "strikeouts=PickemStat_strikeouts",
+            "outs_recorded=PickemStat_outs_recorded",
+            "hits_allowed=PickemStat_hits_allowed",
+            "bb_allowed=PickemStat_bb_allowed",
+        ],
+    )
+    monkeypatch.setattr(cli, "parse_args", lambda: args)
+
+    def fake_import_ud_mlb_lines(algolia_object_id: str) -> pd.DataFrame:
+        if algolia_object_id.endswith("strikeouts"):
+            return pd.DataFrame()
+        if algolia_object_id.endswith("outs_recorded"):
+            raise json.JSONDecodeError("bad payload", "{}", 0)
+        return _live_rows("hits_allowed", "Aaron Nola", "team-away")
+
+    monkeypatch.setattr(cli, "import_ud_mlb_lines", fake_import_ud_mlb_lines)
+
+    def fake_load_pipeline_config(
+        *_: object,
+        stat_override: str | None = None,
+        **__: object,
+    ) -> PipelineConfig:
+        if stat_override == "bb_allowed":
+            raise ConfigValidationError("Missing stat section 'mlb.bb_allowed'")
+        return _config(stat_override or "")
+
+    monkeypatch.setattr(cli, "load_pipeline_config", fake_load_pipeline_config)
+
+    def fake_write_live_pitcher_prop_snapshot(
+        live_lines: pd.DataFrame,
+        stat: str,
+        *,
+        output_dir: Path,
+        snapshot_date: object,
+    ) -> Path:
+        del output_dir, snapshot_date
+        return tmp_path / f"lines/{stat}_2026-03-25.csv"
+
+    monkeypatch.setattr(
+        cli,
+        "write_live_pitcher_prop_snapshot",
+        fake_write_live_pitcher_prop_snapshot,
+    )
+
+    def fake_run_mlb_pitcher_prop_slate(
+        stat_configs: dict[str, PipelineConfig],
+        *,
+        retrain: bool = False,
+        stats: tuple[str, ...] | None = None,
+        scorer: object | None = None,
+    ) -> MlbPitcherPropSlateResult:
+        del retrain, stats, scorer
+        assert set(stat_configs) == {"hits_allowed"}
+        return MlbPitcherPropSlateResult(
+            combined_frame=_slate_frame(),
+            completed_stats=("hits_allowed",),
+            skipped_stats={},
+            failed_stats={},
+        )
+
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        fake_run_mlb_pitcher_prop_slate,
+    )
+
+    returned_summary = cli.main()
+
+    summary_path = tmp_path / "betslips" / "mlb_live_2026-03-25_summary.json"
+    summary = json.loads(summary_path.read_text())
+
+    assert summary["completed_stats"] == ["hits_allowed"]
+    assert summary["skipped_stats"] == {"strikeouts": "no live lines returned"}
+    assert summary["failed_stats"] == {
+        "outs_recorded": "bad payload: line 1 column 1 (char 0)",
+        "bb_allowed": "Missing stat section 'mlb.bb_allowed'",
+    }
+    assert summary["combined_rows"] == 3
+    assert summary["slip_counts"] == {"conservative": 0, "fullsend": 1}
+    assert summary["summary_file"] == str(summary_path)
+    assert returned_summary["summary_file"] == str(summary_path)
+    assert returned_summary == summary
+
+
+def test_build_mlb_live_betslips_propagates_unexpected_fetch_errors(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=["strikeouts=PickemStat_strikeouts"],
+    )
+    monkeypatch.setattr(cli, "parse_args", lambda: args)
+
+    def fake_import_ud_mlb_lines(_: str) -> pd.DataFrame:
+        raise TypeError("boom")
+
+    monkeypatch.setattr(cli, "import_ud_mlb_lines", fake_import_ud_mlb_lines)
+
+    with pytest.raises(TypeError, match="boom"):
+        cli.run_live_shadow_workflow(args)

--- a/tests/test_build_mlb_live_betslips.py
+++ b/tests/test_build_mlb_live_betslips.py
@@ -126,6 +126,7 @@ def test_build_mlb_live_betslips_writes_snapshots_and_json_slips(
 
     args = Namespace(
         config="config/mlb.yaml",
+        mode="proof",
         retrain=False,
         output_dir=tmp_path / "betslips",
         snapshot_dir=tmp_path / "lines",
@@ -149,7 +150,9 @@ def test_build_mlb_live_betslips_writes_snapshots_and_json_slips(
             return _live_rows("strikeouts", "Gerrit Cole", "team-home")
         if algolia_object_id.endswith("outs_recorded"):
             return _live_rows("outs_recorded", "Gerrit Cole", "team-home")
-        return _live_rows("hits_allowed", "Aaron Nola", "team-away")
+        if algolia_object_id.endswith("hits_allowed"):
+            return _live_rows("hits_allowed", "Aaron Nola", "team-away")
+        return pd.DataFrame()
 
     monkeypatch.setattr(cli, "import_ud_mlb_lines", fake_import_ud_mlb_lines)
 
@@ -161,6 +164,23 @@ def test_build_mlb_live_betslips_writes_snapshots_and_json_slips(
         return _config(stat_override or "")
 
     monkeypatch.setattr(cli, "load_pipeline_config", fake_load_pipeline_config)
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {
+                "stat_ids": {
+                    "strikeouts": "PickemStat_config_strikeouts",
+                    "outs_recorded": "PickemStat_config_outs_recorded",
+                    "earned_runs": "PickemStat_config_earned_runs",
+                    "hits_allowed": "PickemStat_config_hits_allowed",
+                    "bb_allowed": "PickemStat_config_bb_allowed",
+                }
+            },
+        )(),
+    )
 
     def fake_run_mlb_pitcher_prop_slate(
         stat_configs: dict[str, PipelineConfig],
@@ -190,7 +210,9 @@ def test_build_mlb_live_betslips_writes_snapshots_and_json_slips(
     assert imported == [
         "PickemStat_strikeouts",
         "PickemStat_outs_recorded",
+        "PickemStat_config_earned_runs",
         "PickemStat_hits_allowed",
+        "PickemStat_config_bb_allowed",
     ]
 
     assert (tmp_path / "lines" / "strikeouts_2026-03-25.csv").exists()
@@ -215,12 +237,30 @@ def test_build_mlb_live_betslips_writes_snapshots_and_json_slips(
         "outs_recorded",
         "hits_allowed",
     ]
+    assert returned_summary["mode"] == "proof"
+    assert returned_summary["outcome"] == "passed"
+    assert returned_summary["failure_reasons"] == []
+    assert returned_summary["warnings"] == []
     assert returned_summary["combined_rows"] == 3
+    assert returned_summary["slip_eligible_rows"] == 3
+    assert returned_summary["stat_mix"] == {
+        "hits_allowed": pytest.approx(1 / 3),
+        "outs_recorded": pytest.approx(1 / 3),
+        "strikeouts": pytest.approx(1 / 3),
+    }
+    assert returned_summary["probability_extremes"] == {"max": 0.62, "min": 0.57}
+    assert returned_summary["ev_extreme"] == {"max": 0.16}
     assert returned_summary["slip_counts"] == {"conservative": 0, "fullsend": 1}
     assert returned_summary["summary_file"] == str(summary_path)
     assert persisted_summary["summary_file"] == str(summary_path)
     assert persisted_summary == returned_summary
     assert "MLB live shadow run" in captured.out
+    assert "FULLSEND SLIPS" in captured.out
+    assert "Slip 1" in captured.out
+    assert "Gerrit Cole" in captured.out
+    assert "strikeouts over 8.5" in captured.out.lower()
+    assert "Aaron Nola" in captured.out
+    assert "hits allowed under 6.5" in captured.out.lower()
 
 
 def test_build_mlb_live_betslips_continues_after_stat_level_failures(
@@ -230,6 +270,7 @@ def test_build_mlb_live_betslips_continues_after_stat_level_failures(
 
     args = Namespace(
         config="config/mlb.yaml",
+        mode="debug",
         retrain=False,
         output_dir=tmp_path / "betslips",
         snapshot_dir=tmp_path / "lines",
@@ -310,6 +351,10 @@ def test_build_mlb_live_betslips_continues_after_stat_level_failures(
     summary = json.loads(summary_path.read_text())
 
     assert summary["completed_stats"] == ["hits_allowed"]
+    assert summary["mode"] == "debug"
+    assert summary["outcome"] == "passed"
+    assert summary["failure_reasons"] == []
+    assert summary["warnings"] == []
     assert summary["skipped_stats"] == {"strikeouts": "no live lines returned"}
     assert summary["failed_stats"] == {
         "outs_recorded": "bad payload: line 1 column 1 (char 0)",
@@ -329,6 +374,7 @@ def test_build_mlb_live_betslips_propagates_unexpected_fetch_errors(
 
     args = Namespace(
         config="config/mlb.yaml",
+        mode="proof",
         retrain=False,
         output_dir=tmp_path / "betslips",
         snapshot_dir=tmp_path / "lines",
@@ -347,3 +393,595 @@ def test_build_mlb_live_betslips_propagates_unexpected_fetch_errors(
 
     with pytest.raises(TypeError, match="boom"):
         cli.run_live_shadow_workflow(args)
+
+
+def test_build_mlb_live_betslips_uses_config_stat_ids_by_default(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="proof",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[],
+    )
+    monkeypatch.setattr(cli, "parse_args", lambda: args)
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {
+                "stat_ids": {
+                    "strikeouts": "PickemStat_config_strikeouts",
+                    "outs_recorded": "PickemStat_config_outs_recorded",
+                    "earned_runs": "PickemStat_config_earned_runs",
+                    "hits_allowed": "PickemStat_config_hits_allowed",
+                    "bb_allowed": "PickemStat_config_bb_allowed",
+                }
+            },
+        )(),
+    )
+
+    imported: list[str] = []
+
+    def fake_import_ud_mlb_lines(algolia_object_id: str) -> pd.DataFrame:
+        imported.append(algolia_object_id)
+        stat = algolia_object_id.removeprefix("PickemStat_config_")
+        return _live_rows(stat, "Pitcher", "team")
+
+    monkeypatch.setattr(cli, "import_ud_mlb_lines", fake_import_ud_mlb_lines)
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=_slate_frame(),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert imported == [
+        "PickemStat_config_strikeouts",
+        "PickemStat_config_outs_recorded",
+        "PickemStat_config_earned_runs",
+        "PickemStat_config_hits_allowed",
+        "PickemStat_config_bb_allowed",
+    ]
+    assert summary["mode"] == "proof"
+    assert summary["outcome"] == "passed"
+    assert summary["warnings"] == []
+
+
+def test_build_mlb_live_betslips_cli_overrides_config_stat_ids(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="debug",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=["strikeouts=PickemStat_cli_strikeouts"],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {
+                "stat_ids": {
+                    "strikeouts": "PickemStat_config_strikeouts",
+                    "outs_recorded": "PickemStat_config_outs_recorded",
+                }
+            },
+        )(),
+    )
+
+    imported: list[str] = []
+
+    def fake_import_ud_mlb_lines(algolia_object_id: str) -> pd.DataFrame:
+        imported.append(algolia_object_id)
+        return _live_rows("strikeouts", "Pitcher", "team")
+
+    monkeypatch.setattr(cli, "import_ud_mlb_lines", fake_import_ud_mlb_lines)
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=_slate_frame(),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert imported == ["PickemStat_cli_strikeouts", "PickemStat_config_outs_recorded"]
+    assert summary["mode"] == "debug"
+    assert summary["outcome"] == "passed"
+    assert summary["warnings"] == []
+
+
+def test_proof_mode_requires_full_supported_market_stat_id_coverage(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="proof",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {"stat_ids": {"strikeouts": "PickemStat_only_strikeouts"}},
+        )(),
+    )
+
+    with pytest.raises(ValueError, match="Missing required MLB stat-id mapping"):
+        cli.run_live_shadow_workflow(args)
+
+
+def test_debug_mode_allows_subset_stat_id_coverage(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="debug",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {"stat_ids": {"strikeouts": "PickemStat_only_strikeouts"}},
+        )(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "import_ud_mlb_lines",
+        lambda _algolia_object_id: _live_rows("strikeouts", "Pitcher", "team"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=_slate_frame(),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert summary["mode"] == "debug"
+    assert summary["stat_ids"] == {"strikeouts": "PickemStat_only_strikeouts"}
+
+
+def test_build_mlb_live_betslips_reports_no_play_slate_explicitly(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="proof",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {
+                "stat_ids": {
+                    "strikeouts": "PickemStat_config_strikeouts",
+                    "outs_recorded": "PickemStat_config_outs_recorded",
+                    "earned_runs": "PickemStat_config_earned_runs",
+                    "hits_allowed": "PickemStat_config_hits_allowed",
+                    "bb_allowed": "PickemStat_config_bb_allowed",
+                }
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "import_ud_mlb_lines",
+        lambda algolia_object_id: _live_rows(
+            algolia_object_id.removeprefix("PickemStat_config_"), "Pitcher", "team"
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=pd.DataFrame(
+                [
+                    {
+                        "player": "Pitcher One",
+                        "player_id": "p1",
+                        "team": "NYY",
+                        "opponent": "BOS",
+                        "game_date": pd.Timestamp("2026-03-25"),
+                        "stat_id": "strikeouts",
+                        "line": 7.5,
+                        "play": "over",
+                        "prob": 0.53,
+                        "ev": -0.01,
+                        "payout": 1.92,
+                        "sport": "MLB",
+                        "market": "strikeouts",
+                        "run_mode": "prediction",
+                        "lines_status": "present",
+                    }
+                ]
+            ),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert summary["outcome"] == "no_play_slate"
+    assert summary["failure_reasons"] == []
+    assert summary["warnings"] == []
+    assert summary["combined_rows"] == 1
+    assert summary["slip_eligible_rows"] == 0
+
+
+def test_proof_mode_fails_on_confidence_gate_extremes(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="proof",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {
+                "stat_ids": {
+                    "strikeouts": "PickemStat_config_strikeouts",
+                    "outs_recorded": "PickemStat_config_outs_recorded",
+                    "earned_runs": "PickemStat_config_earned_runs",
+                    "hits_allowed": "PickemStat_config_hits_allowed",
+                    "bb_allowed": "PickemStat_config_bb_allowed",
+                }
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "import_ud_mlb_lines",
+        lambda algolia_object_id: _live_rows(
+            algolia_object_id.removeprefix("PickemStat_config_"), "Pitcher", "team"
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=pd.DataFrame(
+                [
+                    {
+                        "player": "Pitcher One",
+                        "player_id": "p1",
+                        "team": "NYY",
+                        "opponent": "BOS",
+                        "game_date": pd.Timestamp("2026-03-25"),
+                        "stat_id": "strikeouts",
+                        "line": 7.5,
+                        "play": "over",
+                        "prob": 0.84,
+                        "ev": 0.36,
+                        "payout": 1.92,
+                        "sport": "MLB",
+                        "market": "strikeouts",
+                        "run_mode": "prediction",
+                        "lines_status": "present",
+                    },
+                    {
+                        "player": "Pitcher Two",
+                        "player_id": "p2",
+                        "team": "BOS",
+                        "opponent": "NYY",
+                        "game_date": pd.Timestamp("2026-03-25"),
+                        "stat_id": "hits_allowed",
+                        "line": 6.5,
+                        "play": "under",
+                        "prob": 0.61,
+                        "ev": 0.10,
+                        "payout": 1.95,
+                        "sport": "MLB",
+                        "market": "hits_allowed",
+                        "run_mode": "prediction",
+                        "lines_status": "present",
+                    },
+                ]
+            ),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert summary["outcome"] == "failed"
+    assert summary["failure_reasons"] == ["confidence_gate_failed"]
+    assert summary["warnings"] == []
+
+
+def test_proof_mode_allows_hits_allowed_extremes_with_stat_aware_thresholds(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="proof",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=[],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type(
+            "LiveUnderdogConfig",
+            (),
+            {
+                "stat_ids": {
+                    "strikeouts": "PickemStat_config_strikeouts",
+                    "outs_recorded": "PickemStat_config_outs_recorded",
+                    "earned_runs": "PickemStat_config_earned_runs",
+                    "hits_allowed": "PickemStat_config_hits_allowed",
+                    "bb_allowed": "PickemStat_config_bb_allowed",
+                }
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "import_ud_mlb_lines",
+        lambda algolia_object_id: _live_rows(
+            algolia_object_id.removeprefix("PickemStat_config_"), "Pitcher", "team"
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=pd.DataFrame(
+                [
+                    {
+                        "player": "Michael McGreevy",
+                        "player_id": "p1",
+                        "team": "STL",
+                        "opponent": "MIA",
+                        "game_date": pd.Timestamp("2026-03-25"),
+                        "stat_id": "hits_allowed",
+                        "line": 7.5,
+                        "play": "under",
+                        "prob": 0.919,
+                        "ev": 0.81,
+                        "payout": 1.97,
+                        "sport": "MLB",
+                        "market": "hits_allowed",
+                        "run_mode": "prediction",
+                        "lines_status": "present",
+                    },
+                    {
+                        "player": "Pitcher Two",
+                        "player_id": "p2",
+                        "team": "BOS",
+                        "opponent": "NYY",
+                        "game_date": pd.Timestamp("2026-03-25"),
+                        "stat_id": "outs_recorded",
+                        "line": 17.5,
+                        "play": "under",
+                        "prob": 0.76,
+                        "ev": 0.21,
+                        "payout": 1.95,
+                        "sport": "MLB",
+                        "market": "outs_recorded",
+                        "run_mode": "prediction",
+                        "lines_status": "present",
+                    },
+                ]
+            ),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert summary["outcome"] == "no_play_slate"
+    assert summary["failure_reasons"] == []
+    assert summary["warnings"] == []
+
+
+def test_debug_mode_downgrades_gate_failures_to_warnings(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    from scripts import build_mlb_live_betslips as cli
+
+    args = Namespace(
+        config="config/mlb.yaml",
+        mode="debug",
+        retrain=False,
+        output_dir=tmp_path / "betslips",
+        snapshot_dir=tmp_path / "lines",
+        prefix="mlb_live",
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        stat_ids=["strikeouts=PickemStat_only_strikeouts"],
+    )
+
+    monkeypatch.setattr(
+        cli,
+        "load_pipeline_config",
+        lambda *_args, stat_override=None, **_kwargs: _config(stat_override or ""),
+    )
+    monkeypatch.setattr(
+        cli,
+        "extract_mlb_live_underdog_config",
+        lambda _config: type("LiveUnderdogConfig", (), {"stat_ids": {}})(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "import_ud_mlb_lines",
+        lambda _algolia_object_id: _live_rows("strikeouts", "Pitcher", "team"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "run_mlb_pitcher_prop_slate",
+        lambda stat_configs, **_kwargs: MlbPitcherPropSlateResult(
+            combined_frame=pd.DataFrame(
+                [
+                    {
+                        "player": "Pitcher One",
+                        "player_id": "p1",
+                        "team": "NYY",
+                        "opponent": "BOS",
+                        "game_date": pd.Timestamp("2026-03-25"),
+                        "stat_id": "strikeouts",
+                        "line": 7.5,
+                        "play": "over",
+                        "prob": 0.84,
+                        "ev": 0.36,
+                        "payout": 1.92,
+                        "sport": "MLB",
+                        "market": "strikeouts",
+                        "run_mode": "prediction",
+                        "lines_status": "present",
+                    }
+                ]
+            ),
+            completed_stats=tuple(stat_configs),
+            skipped_stats={},
+            failed_stats={},
+        ),
+    )
+
+    summary = cli.run_live_shadow_workflow(args)
+
+    assert summary["outcome"] == "no_play_slate"
+    assert summary["failure_reasons"] == []
+    assert summary["warnings"] == ["stat_mix_gate_failed", "confidence_gate_failed"]

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -5,7 +5,11 @@ from typing import Any
 
 import pytest
 import yaml
-from src.core.config import ConfigValidationError, load_pipeline_config
+from src.core.config import (
+    ConfigValidationError,
+    extract_mlb_live_underdog_config,
+    load_pipeline_config,
+)
 
 MLB_IMPLEMENTED_STATS: tuple[str, ...] = (
     "strikeouts",
@@ -14,6 +18,19 @@ MLB_IMPLEMENTED_STATS: tuple[str, ...] = (
     "hits_allowed",
     "bb_allowed",
 )
+EXPECTED_MLB_LIVE_UNDERDOG_STAT_IDS: dict[str, str] = {
+    "strikeouts": "PickemStat_de868934-c920-405c-b827-693c15aa47a1",
+    "outs_recorded": "PickemStat_0f4a1b3d-62d9-47f8-9f45-7c2ddf6c8d8e",
+    "earned_runs": "PickemStat_a2f0d1e5-4c4a-4f4c-98f2-8f0f88f7a3d1",
+    "hits_allowed": "PickemStat_9e7e7cb2-58a3-4a3f-86f2-6f07d7dd4d55",
+    "bb_allowed": "PickemStat_7c1f6a0d-0f25-4e1d-8ce8-0c82ff1b0f44",
+}
+EXPECTED_MLB_LIVE_UNDERDOG_DEFAULTS: dict[str, Any] = {
+    "same_pitcher_stacking": True,
+    "min_players_per_slip": 2,
+    "min_teams_per_slip": 2,
+    "json_only": True,
+}
 _MIGRATION_MESSAGE_PATTERN = (
     "sectioned schema.*pipeline\\.sport.*pipeline\\.stat.*\\{sport\\}\\.\\{stat\\}"
 )
@@ -206,6 +223,136 @@ def test_mlb_config_loads_for_all_implemented_stats(stat: str) -> None:
     assert config.sport == "mlb"
     assert config.stat == stat
     assert isinstance(config.section, dict)
+
+
+def test_mlb_live_underdog_config_loads_from_repo_config() -> None:
+    config = load_pipeline_config(
+        "config/mlb.yaml",
+        sport_override="mlb",
+        stat_override="strikeouts",
+    )
+
+    live_underdog = extract_mlb_live_underdog_config(config)
+
+    assert live_underdog.stat_ids == EXPECTED_MLB_LIVE_UNDERDOG_STAT_IDS
+    assert live_underdog.snapshot_output_dir == "data/lines"
+    assert live_underdog.snapshot_filename_template == "{stat}_{date}.csv"
+    assert live_underdog.orchestration_defaults == EXPECTED_MLB_LIVE_UNDERDOG_DEFAULTS
+
+
+def test_mlb_live_underdog_config_defaults_missing_stat_ids(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mlb_live_underdog_partial.yaml"
+    _write_yaml(
+        config_path,
+        {
+            "pipeline": {"sport": "mlb", "stat": "strikeouts"},
+            "mlb": {
+                "strikeouts": {
+                    "pitch_data_path": "data/pitch.csv",
+                    "model_path": "models/model.joblib",
+                    "lines_path": "data/lines.csv",
+                },
+                "live_underdog": {
+                    "stat_ids": {
+                        "strikeouts": "PickemStat_de868934-c920-405c-b827-693c15aa47a1",
+                        "outs_recorded": (
+                            "PickemStat_0f4a1b3d-62d9-47f8-9f45-7c2ddf6c8d8e"
+                        ),
+                    }
+                },
+            },
+        },
+    )
+
+    config = load_pipeline_config(
+        str(config_path),
+        sport_override="mlb",
+        stat_override="strikeouts",
+    )
+    live_underdog = extract_mlb_live_underdog_config(config)
+
+    assert live_underdog.stat_ids == {
+        "strikeouts": "PickemStat_de868934-c920-405c-b827-693c15aa47a1",
+        "outs_recorded": "PickemStat_0f4a1b3d-62d9-47f8-9f45-7c2ddf6c8d8e",
+    }
+    assert live_underdog.snapshot_output_dir == "data/lines"
+    assert live_underdog.snapshot_filename_template == "{stat}_{date}.csv"
+    assert live_underdog.orchestration_defaults == EXPECTED_MLB_LIVE_UNDERDOG_DEFAULTS
+
+
+def test_mlb_live_underdog_config_rejects_unsupported_stat_id_key(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mlb_live_underdog_bad_stat_key.yaml"
+    _write_yaml(
+        config_path,
+        {
+            "pipeline": {"sport": "mlb", "stat": "strikeouts"},
+            "mlb": {
+                "strikeouts": {
+                    "pitch_data_path": "data/pitch.csv",
+                    "model_path": "models/model.joblib",
+                    "lines_path": "data/lines.csv",
+                },
+                "live_underdog": {
+                    "stat_ids": {
+                        "strikeouts": "PickemStat_de868934-c920-405c-b827-693c15aa47a1",
+                        "strikeoutz": "PickemStat_bad",
+                    }
+                },
+            },
+        },
+    )
+
+    config = load_pipeline_config(
+        str(config_path),
+        sport_override="mlb",
+        stat_override="strikeouts",
+    )
+
+    with pytest.raises(ConfigValidationError, match="mlb\\.live_underdog\\.stat_ids"):
+        extract_mlb_live_underdog_config(config)
+
+
+def test_mlb_live_underdog_config_rejects_mis_typed_orchestration_defaults(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "mlb_live_underdog_bad_defaults.yaml"
+    _write_yaml(
+        config_path,
+        {
+            "pipeline": {"sport": "mlb", "stat": "strikeouts"},
+            "mlb": {
+                "strikeouts": {
+                    "pitch_data_path": "data/pitch.csv",
+                    "model_path": "models/model.joblib",
+                    "lines_path": "data/lines.csv",
+                },
+                "live_underdog": {
+                    "stat_ids": {
+                        "strikeouts": "PickemStat_de868934-c920-405c-b827-693c15aa47a1",
+                    },
+                    "orchestration_defaults": {
+                        "same_pitcher_stacking": "true",
+                        "min_players_per_slip": "2",
+                    },
+                },
+            },
+        },
+    )
+
+    config = load_pipeline_config(
+        str(config_path),
+        sport_override="mlb",
+        stat_override="strikeouts",
+    )
+
+    with pytest.raises(
+        ConfigValidationError, match="mlb\\.live_underdog\\.orchestration_defaults"
+    ):
+        extract_mlb_live_underdog_config(config)
 
 
 def test_nfl_config_loads_for_pass_attempts() -> None:

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -19,11 +19,11 @@ MLB_IMPLEMENTED_STATS: tuple[str, ...] = (
     "bb_allowed",
 )
 EXPECTED_MLB_LIVE_UNDERDOG_STAT_IDS: dict[str, str] = {
-    "strikeouts": "PickemStat_de868934-c920-405c-b827-693c15aa47a1",
-    "outs_recorded": "PickemStat_0f4a1b3d-62d9-47f8-9f45-7c2ddf6c8d8e",
-    "earned_runs": "PickemStat_a2f0d1e5-4c4a-4f4c-98f2-8f0f88f7a3d1",
-    "hits_allowed": "PickemStat_9e7e7cb2-58a3-4a3f-86f2-6f07d7dd4d55",
-    "bb_allowed": "PickemStat_7c1f6a0d-0f25-4e1d-8ce8-0c82ff1b0f44",
+    "strikeouts": "PickemStat_311b6775-4d03-4466-8ab9-776442468b27",
+    "outs_recorded": "PickemStat_a74cd651-437c-4e6c-b011-c58789b09db7",
+    "earned_runs": "PickemStat_fccd12d8-bc08-4ec5-b6ee-f027a6ab55b5",
+    "hits_allowed": "PickemStat_4dc8687c-fb40-486a-8be4-31c5a05dd3f1",
+    "bb_allowed": "PickemStat_92390e5a-2c3e-4fc3-a31c-d71f51f97c5c",
 }
 EXPECTED_MLB_LIVE_UNDERDOG_DEFAULTS: dict[str, Any] = {
     "same_pitcher_stacking": True,

--- a/tests/test_mlb_live_features.py
+++ b/tests/test_mlb_live_features.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from datetime import UTC, datetime
 
 import pandas as pd
@@ -420,6 +421,86 @@ def test_primary_fetch_uses_target_date_weather(
     assert not result.empty
     assert float(result.loc[0, "game_temp_f"]) == 70.0
     assert int(result.loc[0, "wind_out_to_cf_flag"]) == 1
+
+
+def test_primary_fetch_deduplicates_schedule_lookups_by_opponent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = LiveContextService({"enabled": True})
+    schedule = pd.DataFrame([{"Date": "Mon, Apr 14", "Temp": 70, "Wind": "9, Out"}])
+    calls: list[tuple[int, str]] = []
+
+    def fake_schedule_and_record(year: int, team: str) -> pd.DataFrame:
+        calls.append((year, team))
+        return schedule.copy()
+
+    monkeypatch.setattr(
+        live_context_module,
+        "schedule_and_record",
+        fake_schedule_and_record,
+    )
+
+    rows = pd.DataFrame(
+        [
+            {"pitcher_id": 101, "opponent_team": "BOS"},
+            {"pitcher_id": 102, "opponent_team": "BOS"},
+            {"pitcher_id": 103, "opponent_team": "NYY"},
+        ]
+    )
+    result = service._fetch_primary(rows, datetime(2025, 4, 14))
+
+    assert len(result) == 3
+    assert calls == [(2025, "BOS"), (2025, "NYY")]
+
+
+def test_primary_fetch_reuses_service_schedule_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = LiveContextService({"enabled": True})
+    schedule = pd.DataFrame([{"Date": "Mon, Apr 14", "Temp": 70, "Wind": "9, Out"}])
+    calls: list[tuple[int, str]] = []
+
+    def fake_schedule_and_record(year: int, team: str) -> pd.DataFrame:
+        calls.append((year, team))
+        return schedule.copy()
+
+    monkeypatch.setattr(
+        live_context_module,
+        "schedule_and_record",
+        fake_schedule_and_record,
+    )
+
+    rows = pd.DataFrame([{"pitcher_id": 101, "opponent_team": "BOS"}])
+    first = service._fetch_primary(rows, datetime(2025, 4, 14))
+    second = service._fetch_primary(rows, datetime(2025, 4, 14))
+
+    assert not first.empty
+    assert not second.empty
+    assert calls == [(2025, "BOS")]
+
+
+def test_primary_fetch_does_not_mutate_process_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = LiveContextService({"enabled": True})
+    schedule = pd.DataFrame([{"Date": "Mon, Apr 14", "Temp": 70, "Wind": "9, Out"}])
+
+    monkeypatch.setattr(
+        live_context_module,
+        "schedule_and_record",
+        lambda _year, _team: schedule.copy(),
+    )
+
+    original_stdout = sys.stdout
+    rows = pd.DataFrame(
+        [
+            {"pitcher_id": 101, "opponent_team": "BOS"},
+            {"pitcher_id": 102, "opponent_team": "NYY"},
+        ]
+    )
+    _ = service._fetch_primary(rows, datetime(2025, 4, 14))
+
+    assert sys.stdout is original_stdout
 
 
 def test_secondary_fetch_matches_team_and_date(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mlb_mixed_prop_slips.py
+++ b/tests/test_mlb_mixed_prop_slips.py
@@ -110,3 +110,72 @@ def test_build_slip_sets_supports_mixed_stat_same_pitcher_stack() -> None:
     assert {leg["lines_status"] for leg in slip["legs"]} == {"present"}
     assert {leg["model_name"] for leg in slip["legs"]} == {"xgboost"}
     assert {leg["model_strategy"] for leg in slip["legs"]} == {"baseline"}
+
+
+def test_build_slip_sets_caps_same_pitcher_stack_at_three_legs() -> None:
+    results = pd.DataFrame(
+        [
+            *_mixed_candidate_rows().to_dict(orient="records"),
+            {
+                "player": "Gerrit Cole",
+                "player_id": "cole-1",
+                "team": "NYY",
+                "opponent": "BOS",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 4,
+                "park_factor": 1.02,
+                "stat_id": "earned_runs",
+                "line": 2.5,
+                "play": "under",
+                "prob": 0.61,
+                "ev": 0.14,
+                "payout": 1.94,
+                "payout_multiplier": 0.94,
+                "run_mode": "prediction",
+                "lines_status": "present",
+                "model_name": "xgboost",
+                "model_strategy": "baseline",
+                "sport": "MLB",
+                "market": "earned_runs",
+            },
+            {
+                "player": "Gerrit Cole",
+                "player_id": "cole-1",
+                "team": "NYY",
+                "opponent": "BOS",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 4,
+                "park_factor": 1.02,
+                "stat_id": "bb_allowed",
+                "line": 1.5,
+                "play": "over",
+                "prob": 0.59,
+                "ev": 0.12,
+                "payout": 1.91,
+                "payout_multiplier": 0.91,
+                "run_mode": "prediction",
+                "lines_status": "present",
+                "model_name": "xgboost",
+                "model_strategy": "baseline",
+                "sport": "MLB",
+                "market": "bb_allowed",
+            },
+        ]
+    )
+    config = SlipBuilderConfig(
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=10,
+        fullsend_min_size=4,
+        fullsend_max_size=4,
+        payout_table={4: 10.0},
+    )
+
+    slip_sets = build_slip_sets(results, config=config)
+
+    assert slip_sets["conservative"] == []
+    assert slip_sets["fullsend"], "Expected at least one valid mixed-stat slip"
+    assert all(
+        sum(leg["player"] == "Gerrit Cole" for leg in slip["legs"]) <= 3
+        for slip in slip_sets["fullsend"]
+    )

--- a/tests/test_mlb_mixed_prop_slips.py
+++ b/tests/test_mlb_mixed_prop_slips.py
@@ -1,0 +1,112 @@
+"""Mixed MLB prop slip tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+from src.mlb.slips import SlipBuilderConfig, build_slip_sets
+
+
+def _mixed_candidate_rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "player": "Gerrit Cole",
+                "player_id": "cole-1",
+                "team": "NYY",
+                "opponent": "BOS",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 4,
+                "park_factor": 1.02,
+                "stat_id": "strikeouts",
+                "line": 8.5,
+                "play": "over",
+                "prob": 0.62,
+                "ev": 0.16,
+                "payout": 1.92,
+                "payout_multiplier": 0.92,
+                "run_mode": "prediction",
+                "lines_status": "present",
+                "model_name": "xgboost",
+                "model_strategy": "baseline",
+                "sport": "MLB",
+                "market": "strikeouts",
+            },
+            {
+                "player": "Gerrit Cole",
+                "player_id": "cole-1",
+                "team": "NYY",
+                "opponent": "BOS",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 4,
+                "park_factor": 1.02,
+                "stat_id": "outs_recorded",
+                "line": 18.5,
+                "play": "over",
+                "prob": 0.58,
+                "ev": 0.11,
+                "payout": 1.9,
+                "payout_multiplier": 0.9,
+                "run_mode": "prediction",
+                "lines_status": "present",
+                "model_name": "xgboost",
+                "model_strategy": "baseline",
+                "sport": "MLB",
+                "market": "outs_recorded",
+            },
+            {
+                "player": "Aaron Nola",
+                "player_id": "nola-1",
+                "team": "PHI",
+                "opponent": "ATL",
+                "game_date": pd.Timestamp("2026-03-25"),
+                "rest_days": 5,
+                "park_factor": 0.97,
+                "stat_id": "hits_allowed",
+                "line": 6.5,
+                "play": "under",
+                "prob": 0.57,
+                "ev": 0.13,
+                "payout": 2.05,
+                "payout_multiplier": 1.05,
+                "run_mode": "prediction",
+                "lines_status": "present",
+                "model_name": "xgboost",
+                "model_strategy": "baseline",
+                "sport": "MLB",
+                "market": "hits_allowed",
+            },
+        ]
+    )
+
+
+def test_build_slip_sets_supports_mixed_stat_same_pitcher_stack() -> None:
+    results = _mixed_candidate_rows()
+    config = SlipBuilderConfig(
+        top_n=10,
+        conservative_count=0,
+        fullsend_count=1,
+        fullsend_min_size=3,
+        fullsend_max_size=3,
+        payout_table={3: 6.0},
+    )
+
+    slip_sets = build_slip_sets(results, config=config)
+
+    assert slip_sets["conservative"] == []
+    assert len(slip_sets["fullsend"]) == 1
+
+    slip = slip_sets["fullsend"][0]
+    assert sum(leg["player"] == "Gerrit Cole" for leg in slip["legs"]) == 2
+    assert {leg["team"] for leg in slip["legs"]} == {"NYY", "PHI"}
+    assert {leg["stat_id"] for leg in slip["legs"]} == {
+        "strikeouts",
+        "outs_recorded",
+        "hits_allowed",
+    }
+    assert {leg["opponent"] for leg in slip["legs"]} == {"BOS", "ATL"}
+    assert {leg["rest_days"] for leg in slip["legs"]} == {4, 5}
+    assert {leg["park_factor"] for leg in slip["legs"]} == {1.02, 0.97}
+    assert {leg["run_mode"] for leg in slip["legs"]} == {"prediction"}
+    assert {leg["lines_status"] for leg in slip["legs"]} == {"present"}
+    assert {leg["model_name"] for leg in slip["legs"]} == {"xgboost"}
+    assert {leg["model_strategy"] for leg in slip["legs"]} == {"baseline"}

--- a/tests/test_mlb_pitcher_prop_data_integrity.py
+++ b/tests/test_mlb_pitcher_prop_data_integrity.py
@@ -6,6 +6,7 @@ from src.mlb.pitcher_props.descriptors import get_stat_descriptor
 from src.mlb.pitcher_props.pipeline import (
     _add_opponent_tendency,
     _build_prediction_rows,
+    _build_training_games,
 )
 
 
@@ -185,6 +186,116 @@ def test_build_pitcher_game_table_deduplicates_terminal_plate_appearances() -> N
 
     assert float(row["hits_allowed"]) == 1.0
     assert float(row["outs_recorded"]) == 1.0
+
+
+def test_build_pitcher_game_table_marks_starter_from_first_inning() -> None:
+    frame = pd.DataFrame(
+        [
+            {
+                "pitcher": 1,
+                "player_name": "Starter, Sam",
+                "game_date": "2024-04-01",
+                "game_pk": 1001,
+                "at_bat_number": 1,
+                "pitch_number": 1,
+                "events": "single",
+                "description": "hit_into_play",
+                "inning": 1,
+                "pitch_type": "FF",
+                "home_team": "NYM",
+                "away_team": "ATL",
+                "pitcher_days_since_prev_game": 5,
+                "inning_topbot": "Top",
+            },
+            {
+                "pitcher": 2,
+                "player_name": "Reliever, Ron",
+                "game_date": "2024-04-01",
+                "game_pk": 1001,
+                "at_bat_number": 2,
+                "pitch_number": 1,
+                "events": "single",
+                "description": "hit_into_play",
+                "inning": 6,
+                "pitch_type": "SL",
+                "home_team": "NYM",
+                "away_team": "ATL",
+                "pitcher_days_since_prev_game": 2,
+                "inning_topbot": "Top",
+            },
+        ]
+    )
+
+    games = (
+        build_pitcher_game_table(frame)
+        .sort_values("pitcher_id")
+        .reset_index(drop=True)
+    )
+
+    assert int(games.loc[0, "is_starter"]) == 1
+    assert int(games.loc[1, "is_starter"]) == 0
+
+
+def test_build_training_games_filters_non_starters_for_pitcher_props(
+    monkeypatch,
+) -> None:
+    descriptor = get_stat_descriptor("outs_recorded")
+
+    games = pd.DataFrame(
+        [
+            {
+                "pitcher": 1,
+                "pitcher_id": 1,
+                "pitcher_name": "Starter Sam",
+                "game_date": "2024-04-01",
+                "pitch_count": 92,
+                "strikeouts": 6,
+                "outs_recorded": 18,
+                "on_base_events_allowed": 4,
+                "hard_contact_rate_allowed": 0.30,
+                "rest_days": 5,
+                "home_team": "NYM",
+                "opponent_team": "ATL",
+                "is_starter": 1,
+            },
+            {
+                "pitcher": 2,
+                "pitcher_id": 2,
+                "pitcher_name": "Reliever Ron",
+                "game_date": "2024-04-01",
+                "pitch_count": 18,
+                "strikeouts": 1,
+                "outs_recorded": 2,
+                "on_base_events_allowed": 1,
+                "hard_contact_rate_allowed": 0.10,
+                "rest_days": 2,
+                "home_team": "NYM",
+                "opponent_team": "ATL",
+                "is_starter": 0,
+            },
+        ]
+    )
+    games["game_date"] = pd.to_datetime(games["game_date"])
+
+    monkeypatch.setattr(
+        "src.mlb.pitcher_props.pipeline.read_csv",
+        lambda _path: pd.DataFrame(),
+    )
+    monkeypatch.setattr(
+        "src.mlb.pitcher_props.pipeline.persist_reusable_tables",
+        lambda *args, **kwargs: (games.copy(), pd.DataFrame()),
+    )
+
+    training_games = _build_training_games(
+        {
+            "pitch_data_path": "data/raw/statcast/statcast_raw_2026.parquet",
+            "training_data_paths": ["data/raw/statcast/statcast_raw_2026.parquet"],
+        },
+        descriptor,
+    )
+
+    assert training_games["pitcher_name"].tolist() == ["Starter Sam"]
+    assert training_games["outs_recorded"].tolist() == [18]
 
 
 def test_build_pitcher_game_table_earned_runs_fallback_uses_game_level_value() -> None:

--- a/tests/test_mlb_pitcher_prop_derivations.py
+++ b/tests/test_mlb_pitcher_prop_derivations.py
@@ -9,6 +9,7 @@ def test_build_pitcher_game_table_derives_multi_targets() -> None:
         [
             {
                 "pitcher": 1,
+                "player_name": "Cole, Gerrit",
                 "game_date": "2024-04-01",
                 "description": "called_strike",
                 "events": "strikeout",
@@ -29,6 +30,7 @@ def test_build_pitcher_game_table_derives_multi_targets() -> None:
             },
             {
                 "pitcher": 1,
+                "player_name": "Cole, Gerrit",
                 "game_date": "2024-04-01",
                 "description": "hit_into_play",
                 "events": "grounded_into_double_play",
@@ -49,6 +51,7 @@ def test_build_pitcher_game_table_derives_multi_targets() -> None:
             },
             {
                 "pitcher": 1,
+                "player_name": "Cole, Gerrit",
                 "game_date": "2024-04-01",
                 "description": "ball",
                 "events": "walk",
@@ -69,6 +72,7 @@ def test_build_pitcher_game_table_derives_multi_targets() -> None:
             },
             {
                 "pitcher": 1,
+                "player_name": "Cole, Gerrit",
                 "game_date": "2024-04-01",
                 "description": "hit_into_play",
                 "events": "single",
@@ -97,6 +101,8 @@ def test_build_pitcher_game_table_derives_multi_targets() -> None:
     assert float(row["hits_allowed"]) == 1.0
     assert float(row["bb_allowed"]) == 1.0
     assert float(row["earned_runs"]) == 1.0
+    assert row["pitcher_id"] == 1
+    assert row["pitcher_name"] == "Gerrit Cole"
 
 
 def test_build_batter_game_table_builds_foundation_columns() -> None:

--- a/tests/test_mlb_pitcher_prop_live_lines.py
+++ b/tests/test_mlb_pitcher_prop_live_lines.py
@@ -114,6 +114,21 @@ def test_normalize_live_pitcher_prop_lines_falls_back_to_player_when_name_blank(
     assert list(frame["player_name"]) == ["Aaron Nola", "Zack Wheeler"]
 
 
+def test_normalize_live_pitcher_prop_lines_keeps_uuid_backed_provider_stat_ids(
+) -> None:
+    frame = _unified_rows("strikeouts").copy()
+    frame["stat_id"] = "311b6775-4d03-4466-8ab9-776442468b27"
+
+    normalized = normalize_live_pitcher_prop_lines(frame, "strikeouts")
+
+    assert list(normalized["player"]) == ["Aaron Nola", "Dylan Cease", "Zack Wheeler"]
+    assert normalized["stat_id"].tolist() == [
+        "311b6775-4d03-4466-8ab9-776442468b27",
+        "311b6775-4d03-4466-8ab9-776442468b27",
+        "311b6775-4d03-4466-8ab9-776442468b27",
+    ]
+
+
 @pytest.mark.parametrize("stat", SUPPORTED_STATS)
 def test_write_live_pitcher_prop_snapshot_writes_deterministic_csv(
     tmp_path: Path,

--- a/tests/test_mlb_pitcher_prop_live_lines.py
+++ b/tests/test_mlb_pitcher_prop_live_lines.py
@@ -1,0 +1,156 @@
+"""Tests for MLB live line normalization and snapshot writing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from src.mlb.data.load_props import load_pitcher_prop_lines
+from src.mlb.pitcher_props.descriptors import STAT_DESCRIPTORS
+from src.mlb.pitcher_props.live_lines import (
+    normalize_live_pitcher_prop_lines,
+    write_live_pitcher_prop_snapshot,
+)
+
+SUPPORTED_STATS = tuple(STAT_DESCRIPTORS.keys())
+
+
+def _unified_rows(
+    target_stat: str,
+    *,
+    player_name_override: str | None = None,
+) -> pd.DataFrame:
+    other_stat = next(stat for stat in SUPPORTED_STATS if stat != target_stat)
+    target_player_name = player_name_override or "Zack Wheeler"
+    return pd.DataFrame(
+        [
+            {
+                "appearance_id": "appearance-z",
+                "player_ud_id": "player-z",
+                "player": "Zack Wheeler",
+                "player_name": target_player_name,
+                "game_id": "game-2",
+                "team_id": "team-home",
+                "line": 8.5,
+                "book": "Underdog",
+                "scheduled_at": "2026-03-25T19:05:00Z",
+                "season_type": "regular",
+                "stat_id": target_stat,
+                "over_decimal_price": 1.92,
+                "over_payout_multiplier": 0.92,
+                "over_american_price": -110,
+                "under_decimal_price": 1.88,
+                "under_payout_multiplier": 0.88,
+                "under_american_price": -115,
+            },
+            {
+                "appearance_id": "appearance-d",
+                "player_ud_id": "player-d",
+                "player": "Dylan Cease",
+                "player_name": "Dylan Cease",
+                "game_id": "game-3",
+                "team_id": "team-away",
+                "line": 6.5,
+                "book": "Underdog",
+                "scheduled_at": "2026-03-25T20:15:00Z",
+                "season_type": "regular",
+                "stat_id": other_stat,
+                "over_decimal_price": 1.95,
+                "over_payout_multiplier": 0.95,
+                "over_american_price": -105,
+                "under_decimal_price": 1.85,
+                "under_payout_multiplier": 0.85,
+                "under_american_price": -120,
+            },
+            {
+                "appearance_id": "appearance-a",
+                "player_ud_id": "player-a",
+                "player": "Aaron Nola",
+                "player_name": "Aaron Nola",
+                "game_id": "game-1",
+                "team_id": "team-away",
+                "line": 7.5,
+                "book": "Underdog",
+                "scheduled_at": "2026-03-25T18:35:00Z",
+                "season_type": "regular",
+                "stat_id": target_stat,
+                "over_decimal_price": 1.9,
+                "over_payout_multiplier": 0.9,
+                "over_american_price": -111,
+                "under_decimal_price": 1.9,
+                "under_payout_multiplier": 0.9,
+                "under_american_price": -111,
+            },
+        ]
+    )
+
+
+@pytest.mark.parametrize("stat", SUPPORTED_STATS)
+def test_normalize_live_pitcher_prop_lines_maps_supported_stat_columns(
+    stat: str,
+) -> None:
+    frame = normalize_live_pitcher_prop_lines(_unified_rows(stat), stat)
+    descriptor = STAT_DESCRIPTORS[stat]
+
+    assert list(frame["player"]) == ["Aaron Nola", "Zack Wheeler"]
+    assert descriptor.line_col in frame.columns
+    assert frame[descriptor.line_col].tolist() == [7.5, 8.5]
+    assert frame["stat_id"].tolist() == [stat, stat]
+    assert frame["over_decimal_price"].tolist() == [1.9, 1.92]
+    assert frame["under_decimal_price"].tolist() == [1.9, 1.88]
+
+
+@pytest.mark.parametrize("stat", SUPPORTED_STATS)
+def test_normalize_live_pitcher_prop_lines_falls_back_to_player_when_name_blank(
+    stat: str,
+) -> None:
+    frame = normalize_live_pitcher_prop_lines(
+        _unified_rows(stat, player_name_override="   "),
+        stat,
+    )
+
+    assert list(frame["player"]) == ["Aaron Nola", "Zack Wheeler"]
+    assert list(frame["player_name"]) == ["Aaron Nola", "Zack Wheeler"]
+
+
+@pytest.mark.parametrize("stat", SUPPORTED_STATS)
+def test_write_live_pitcher_prop_snapshot_writes_deterministic_csv(
+    tmp_path: Path,
+    stat: str,
+) -> None:
+    descriptor = STAT_DESCRIPTORS[stat]
+    output_path = write_live_pitcher_prop_snapshot(
+        _unified_rows(stat),
+        stat,
+        output_dir=tmp_path,
+        snapshot_date=pd.Timestamp("2026-03-25T12:34:56Z"),
+    )
+
+    assert output_path == tmp_path / f"{stat}_2026-03-25.csv"
+    assert output_path.exists()
+
+    loaded = load_pitcher_prop_lines(str(output_path), descriptor.line_col)
+    assert list(loaded["player"]) == ["Aaron Nola", "Zack Wheeler"]
+    assert loaded[descriptor.line_col].tolist() == [7.5, 8.5]
+    assert loaded["stat_id"].tolist() == [stat, stat]
+    assert loaded["book"].tolist() == ["Underdog", "Underdog"]
+
+
+def test_normalize_live_pitcher_prop_lines_returns_empty_frame_for_missing_stat(
+) -> None:
+    frame = normalize_live_pitcher_prop_lines(_unified_rows("strikeouts"), "bb_allowed")
+
+    assert frame.empty
+    assert "bb_line" in frame.columns
+    assert "player" in frame.columns
+
+
+@pytest.mark.parametrize("missing_column", ["game_id", "appearance_id", "scheduled_at"])
+def test_normalize_live_pitcher_prop_lines_rejects_missing_sort_columns(
+    missing_column: str,
+) -> None:
+    frame = _unified_rows("strikeouts").drop(columns=[missing_column])
+
+    with pytest.raises(ValueError, match=missing_column):
+        normalize_live_pitcher_prop_lines(frame, "strikeouts")

--- a/tests/test_mlb_pitcher_prop_slate.py
+++ b/tests/test_mlb_pitcher_prop_slate.py
@@ -1,0 +1,119 @@
+"""Tests for unified MLB pitcher-prop slate orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from src.core.contracts import PipelineConfig
+from src.mlb.pitcher_props.slate import run_mlb_pitcher_prop_slate
+
+
+def _pipeline_config(stat: str) -> PipelineConfig:
+    return PipelineConfig(
+        config_path=Path("config/mlb.yaml"),
+        sport="mlb",
+        stat=stat,
+        raw={"pipeline": {"sport": "mlb", "stat": stat}},
+        section={"stat": stat},
+    )
+
+
+def _scored_frame(stat: str, player: str, line: float) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "player": player,
+                "predicted_value": line + 1.0,
+                "prob_over": 0.61,
+                "prob_under": 0.39,
+                "ev_over": 0.12,
+                "ev_under": -0.05,
+                "run_mode": "prediction",
+                "lines_status": "present",
+            }
+        ]
+    )
+
+
+def test_run_mlb_pitcher_prop_slate_combines_successful_stats_and_tracks_skips(
+    ) -> None:
+    completed = {
+        "strikeouts": _pipeline_config("strikeouts"),
+        "outs_recorded": _pipeline_config("outs_recorded"),
+        "earned_runs": None,
+        "hits_allowed": _pipeline_config("hits_allowed"),
+        "bb_allowed": _pipeline_config("bb_allowed"),
+    }
+
+    def scorer(config: PipelineConfig, retrain: bool = False) -> pd.DataFrame:
+        del retrain
+        if config.stat == "strikeouts":
+            return _scored_frame("strikeouts", "Gerrit Cole", 7.5)
+        if config.stat == "outs_recorded":
+            return _scored_frame("outs_recorded", "Zack Wheeler", 17.5)
+        if config.stat == "hits_allowed":
+            raise FileNotFoundError(
+                "Pitcher prop lines file not found: /tmp/hits_allowed_2026-03-25.csv"
+            )
+        if config.stat == "bb_allowed":
+            raise FileNotFoundError("could not open /tmp/model.joblib")
+        return pd.DataFrame()
+
+    result = run_mlb_pitcher_prop_slate(completed, scorer=scorer)
+
+    assert list(result.completed_stats) == ["strikeouts", "outs_recorded"]
+    assert result.skipped_stats == {
+        "earned_runs": "no config provided",
+        "hits_allowed": (
+            "Pitcher prop lines file not found: "
+            "/tmp/hits_allowed_2026-03-25.csv"
+        ),
+    }
+    assert result.failed_stats == {"bb_allowed": "could not open /tmp/model.joblib"}
+    assert list(result.combined_frame["stat_id"]) == ["strikeouts", "outs_recorded"]
+    assert list(result.combined_frame["player"]) == ["Gerrit Cole", "Zack Wheeler"]
+
+
+def test_run_mlb_pitcher_prop_slate_returns_stable_empty_schema_when_no_rows() -> None:
+    config = {"strikeouts": _pipeline_config("strikeouts")}
+
+    def scorer(config: PipelineConfig, retrain: bool = False) -> pd.DataFrame:
+        del config, retrain
+        return pd.DataFrame()
+
+    result = run_mlb_pitcher_prop_slate(config, scorer=scorer, stats=["strikeouts"])
+
+    assert result.completed_stats == ()
+    assert result.skipped_stats == {"strikeouts": "no scored frame returned"}
+    assert result.failed_stats == {}
+    assert result.combined_frame.empty
+    assert list(result.combined_frame.columns) == [
+        "stat_id",
+        "player",
+        "predicted_value",
+        "prob_over",
+        "prob_under",
+        "ev_over",
+        "ev_under",
+        "run_mode",
+        "lines_status",
+    ]
+
+
+def test_run_mlb_pitcher_prop_slate_rejects_unsupported_explicit_stats() -> None:
+    config = {"strikeouts": _pipeline_config("strikeouts")}
+
+    def scorer(config: PipelineConfig, retrain: bool = False) -> pd.DataFrame:
+        del config, retrain
+        return _scored_frame("strikeouts", "Gerrit Cole", 7.5)
+
+    try:
+        run_mlb_pitcher_prop_slate(config, scorer=scorer, stats=["strikouts"])
+    except ValueError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive branch
+        raise AssertionError("Expected unsupported stat to raise ValueError")
+
+    assert "Unsupported MLB pitcher-prop stat(s): ['strikouts']" in message
+    assert "strikeouts" in message

--- a/tests/test_mlb_underdog_lines.py
+++ b/tests/test_mlb_underdog_lines.py
@@ -1,0 +1,135 @@
+"""Tests for MLB Underdog line ingestion helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pytest
+from src.mlb.data.underdog import _extract_lines, import_ud_mlb_lines
+
+
+def _payload(stat_id: str) -> dict[str, Any]:
+    return {
+        "appearances": [
+            {
+                "id": "appearance-1",
+                "player_id": "player-1",
+                "match_id": "game-1",
+                "team_id": "team-home",
+            }
+        ],
+        "games": [
+            {
+                "id": "game-1",
+                "scheduled_at": "2026-03-25T19:05:00Z",
+                "season_type": "regular",
+                "home_team_id": "team-home",
+                "away_team_id": "team-away",
+            }
+        ],
+        "players": [
+            {
+                "id": "player-1",
+                "first_name": "Gerrit",
+                "last_name": "Cole",
+            }
+        ],
+        "over_under_lines": [
+            {
+                "stat_value": 8.5,
+                "over_under": {
+                    "appearance_stat": {
+                        "pickem_stat_id": stat_id,
+                        "appearance_id": "appearance-1",
+                    }
+                },
+                "options": [
+                    {
+                        "choice": "higher",
+                        "decimal_price": 1.92,
+                        "payout_multiplier": 0.92,
+                        "american_price": -110,
+                    },
+                    {
+                        "choice": "lower",
+                        "decimal_price": 1.88,
+                        "payout_multiplier": 0.88,
+                        "american_price": -115,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def test_extract_lines_normalizes_matching_stat() -> None:
+    frame = _extract_lines(_payload("strikeouts"), "strikeouts")
+
+    expected = pd.DataFrame(
+        [
+            {
+                "appearance_id": "appearance-1",
+                "player_ud_id": "player-1",
+                "player_name": "Gerrit Cole",
+                "game_id": "game-1",
+                "team_id": "team-home",
+                "line": 8.5,
+                "book": "Underdog",
+                "scheduled_at": "2026-03-25T19:05:00Z",
+                "season_type": "regular",
+                "stat_id": "strikeouts",
+                "over_decimal_price": 1.92,
+                "over_payout_multiplier": 0.92,
+                "over_american_price": -110,
+                "under_decimal_price": 1.88,
+                "under_payout_multiplier": 0.88,
+                "under_american_price": -115,
+            }
+        ]
+    )
+
+    pd.testing.assert_frame_equal(frame.reset_index(drop=True), expected)
+
+
+def test_extract_lines_returns_empty_frame_for_non_matching_stat() -> None:
+    frame = _extract_lines(_payload("strikeouts"), "bb_allowed")
+
+    assert frame.empty
+
+
+def test_import_ud_mlb_lines_uses_stat_id_from_algolia_object_id(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_fetch_payload(algolia_object_id: str) -> dict[str, Any]:
+        captured["algolia_object_id"] = algolia_object_id
+        return _payload("earned_runs")
+
+    monkeypatch.setattr(
+        "src.mlb.data.underdog._fetch_payload",
+        fake_fetch_payload,
+    )
+
+    frame = import_ud_mlb_lines(
+        algolia_object_id="PickemStat_earned_runs",
+    )
+
+    assert captured["algolia_object_id"] == "PickemStat_earned_runs"
+    assert frame.loc[0, "stat_id"] == "earned_runs"
+
+
+def test_import_ud_mlb_lines_rejects_malformed_algolia_object_id(
+    monkeypatch: Any,
+) -> None:
+    def fake_fetch_payload(algolia_object_id: str) -> dict[str, Any]:
+        raise AssertionError(f"unexpected fetch: {algolia_object_id}")
+
+    monkeypatch.setattr(
+        "src.mlb.data.underdog._fetch_payload",
+        fake_fetch_payload,
+    )
+
+    with pytest.raises(ValueError, match="PickemStat_<stat-id>"):
+        import_ud_mlb_lines(algolia_object_id="earned_runs")

--- a/tests/test_mlb_underdog_lines.py
+++ b/tests/test_mlb_underdog_lines.py
@@ -98,6 +98,25 @@ def test_extract_lines_returns_empty_frame_for_non_matching_stat() -> None:
     assert frame.empty
 
 
+def test_extract_lines_falls_back_when_payload_appearance_ids_do_not_match() -> None:
+    payload = _payload("strikeouts")
+    payload["appearances"][0]["id"] = "current-appearance-id"
+    payload["players"][0]["team_id"] = "team-home"
+    payload["over_under_lines"][0]["over_under"]["appearance_stat"]["appearance_id"] = (
+        "legacy-appearance-id"
+    )
+    payload["over_under_lines"][0]["options"][0]["selection_header"] = "Gerrit Cole"
+    payload["over_under_lines"][0]["options"][1]["selection_header"] = "Gerrit Cole"
+
+    frame = _extract_lines(payload, "strikeouts")
+
+    assert len(frame) == 1
+    assert frame.loc[0, "appearance_id"] == "current-appearance-id"
+    assert frame.loc[0, "player_ud_id"] == "player-1"
+    assert frame.loc[0, "game_id"] == "game-1"
+    assert frame.loc[0, "team_id"] == "team-home"
+
+
 def test_import_ud_mlb_lines_uses_stat_id_from_algolia_object_id(
     monkeypatch: Any,
 ) -> None:

--- a/tests/test_print_slips.py
+++ b/tests/test_print_slips.py
@@ -1,0 +1,151 @@
+"""Tests for the slip-printing CLI."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+
+def _slip_payload(
+    player: str, stat_id: str, play: str, line: float
+) -> dict[str, object]:
+    """Return a minimal slip payload for formatting tests.
+
+    Args:
+        player: Player name shown in the report.
+        stat_id: Market stat identifier.
+        play: Pick direction.
+        line: Sportsbook line.
+
+    Returns:
+        Slip payload compatible with the live MLB artifact format.
+    """
+
+    return {
+        "slips": [
+            {
+                "slip_size": 1,
+                "units": 1,
+                "p_win": 0.62,
+                "total_ev": 0.25,
+                "legs": [
+                    {
+                        "player": player,
+                        "team": "NYY",
+                        "opponent": "BOS",
+                        "stat_id": stat_id,
+                        "play": play,
+                        "line": line,
+                        "prob": 0.62,
+                        "ev": 0.25,
+                        f"predicted_{stat_id}": line + 1.0,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _write_summary_fixture(tmp_path: Path) -> Path:
+    """Write a summary plus referenced slip files for tests.
+
+    Args:
+        tmp_path: Temporary test directory.
+
+    Returns:
+        Path to the generated summary artifact.
+    """
+
+    conservative_path = tmp_path / "mlb_live_2026-03-25_conservative.json"
+    conservative_path.write_text(
+        json.dumps(_slip_payload("Gerrit Cole", "strikeouts", "over", 8.5)),
+        encoding="utf-8",
+    )
+
+    fullsend_path = tmp_path / "mlb_live_2026-03-25_fullsend.json"
+    fullsend_path.write_text(
+        json.dumps(_slip_payload("Aaron Nola", "hits_allowed", "under", 6.5)),
+        encoding="utf-8",
+    )
+
+    summary_path = tmp_path / "mlb_live_2026-03-25_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "target_date": "2026-03-25",
+                "slip_files": {
+                    "conservative": str(conservative_path),
+                    "fullsend": str(fullsend_path),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return summary_path
+
+
+def test_print_slips_renders_all_summary_sections(
+    monkeypatch: object, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The script prints all slip sections when no tag filter is provided."""
+
+    from scripts import print_slips as cli
+
+    summary_path = _write_summary_fixture(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda: Namespace(summary_path=summary_path, tag=None),
+    )
+
+    cli.main()
+    captured = capsys.readouterr()
+
+    assert "CONSERVATIVE SLIPS" in captured.out
+    assert "FULLSEND SLIPS" in captured.out
+    assert "Gerrit Cole" in captured.out
+    assert "Aaron Nola" in captured.out
+
+
+def test_print_slips_limits_output_to_selected_tag(
+    monkeypatch: object, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The script filters output to a single slip section when requested."""
+
+    from scripts import print_slips as cli
+
+    summary_path = _write_summary_fixture(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda: Namespace(summary_path=summary_path, tag="fullsend"),
+    )
+
+    cli.main()
+    captured = capsys.readouterr()
+
+    assert "CONSERVATIVE SLIPS" not in captured.out
+    assert "FULLSEND SLIPS" in captured.out
+    assert "Aaron Nola" in captured.out
+    assert "Gerrit Cole" not in captured.out
+
+
+def test_print_slips_raises_for_missing_summary_tag(
+    monkeypatch: object, tmp_path: Path
+) -> None:
+    """The script fails clearly when the requested tag is unavailable."""
+
+    from scripts import print_slips as cli
+
+    summary_path = _write_summary_fixture(tmp_path)
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda: Namespace(summary_path=summary_path, tag="nonexistent"),
+    )
+
+    with pytest.raises(ValueError, match="Requested slip tag"):
+        cli.main()

--- a/tests/test_slips.py
+++ b/tests/test_slips.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
-from src.mlb.slips import generate_slips
+from src.mlb.slips import generate_slips, prepare_long_df
 
 
 def test_generate_slips_uses_leg_multipliers() -> None:
@@ -51,3 +51,96 @@ def test_generate_slips_uses_leg_multipliers() -> None:
     assert slip["payout"] == pytest.approx(expected_payout)
     assert slip["p_win"] == expected_p_win
     assert slip["total_ev"] == expected_total_ev
+    assert slip["legs"][0]["opponent"] == "BBB"
+    assert slip["legs"][0]["game_date"] == "2025-04-01T00:00:00"
+    assert slip["legs"][0]["rest_days"] == 3
+    assert slip["legs"][0]["park_factor"] == 1.0
+
+
+def test_generate_slips_rejects_slips_without_two_teams() -> None:
+    data = [
+        {
+            "player": "Player A",
+            "player_id": "a",
+            "team": "AAA",
+            "opponent": "BBB",
+            "game_date": pd.Timestamp("2025-04-01"),
+            "rest_days": 3,
+            "park_factor": 1.0,
+            "stat_id": "strikeouts",
+            "line": 5.5,
+            "play": "over",
+            "prob": 0.6,
+            "ev": 0.2,
+            "payout": 1.9,
+            "payout_multiplier": 0.9,
+        },
+        {
+            "player": "Player B",
+            "player_id": "b",
+            "team": "AAA",
+            "opponent": "CCC",
+            "game_date": pd.Timestamp("2025-04-01"),
+            "rest_days": 4,
+            "park_factor": 0.95,
+            "stat_id": "outs_recorded",
+            "line": 15.5,
+            "play": "under",
+            "prob": 0.55,
+            "ev": 0.15,
+            "payout": 2.1,
+            "payout_multiplier": 0.91,
+        },
+        {
+            "player": "Player C",
+            "player_id": "c",
+            "team": "AAA",
+            "opponent": "DDD",
+            "game_date": pd.Timestamp("2025-04-01"),
+            "rest_days": 5,
+            "park_factor": 1.05,
+            "stat_id": "hits_allowed",
+            "line": 6.5,
+            "play": "over",
+            "prob": 0.5,
+            "ev": 0.1,
+            "payout": 1.95,
+            "payout_multiplier": 0.92,
+        },
+    ]
+
+    df = pd.DataFrame(data)
+
+    slips = generate_slips(df, slip_size=3, payout_table={3: 6.0})
+
+    assert slips == []
+
+
+def test_prepare_long_df_preserves_legacy_context_fields() -> None:
+    results = pd.DataFrame(
+        [
+            {
+                "player": "Player A",
+                "pitcher_id": "a",
+                "pitcher_team": "AAA",
+                "upcoming_opponent": "BBB",
+                "upcoming_game_date": pd.Timestamp("2025-04-01"),
+                "upcoming_rest_days": 3,
+                "upcoming_park_factor_K": 1.1,
+                "k_line": 5.5,
+                "prob_over": 0.6,
+                "prob_under": 0.4,
+                "ev_over": 0.2,
+                "ev_under": -0.1,
+                "over_decimal_price": 1.9,
+                "under_decimal_price": 1.8,
+            }
+        ]
+    )
+
+    long_df = prepare_long_df(results, min_ev=-1.0)
+
+    assert list(long_df["opponent"]) == ["BBB", "BBB"]
+    assert list(long_df["game_date"]) == [pd.Timestamp("2025-04-01")] * 2
+    assert list(long_df["rest_days"]) == [3, 3]
+    assert list(long_df["park_factor"]) == [1.1, 1.1]

--- a/tests/test_slips.py
+++ b/tests/test_slips.py
@@ -116,6 +116,92 @@ def test_generate_slips_rejects_slips_without_two_teams() -> None:
     assert slips == []
 
 
+def test_generate_slips_rejects_more_than_three_legs_for_one_player() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "player": "Player A",
+                "player_id": "a",
+                "team": "AAA",
+                "opponent": "BBB",
+                "game_date": pd.Timestamp("2025-04-01"),
+                "rest_days": 3,
+                "park_factor": 1.0,
+                "stat_id": "strikeouts",
+                "line": 5.5,
+                "play": "over",
+                "prob": 0.6,
+                "ev": 0.2,
+                "payout": 1.9,
+            },
+            {
+                "player": "Player A",
+                "player_id": "a",
+                "team": "AAA",
+                "opponent": "BBB",
+                "game_date": pd.Timestamp("2025-04-01"),
+                "rest_days": 3,
+                "park_factor": 1.0,
+                "stat_id": "outs_recorded",
+                "line": 15.5,
+                "play": "under",
+                "prob": 0.58,
+                "ev": 0.18,
+                "payout": 1.95,
+            },
+            {
+                "player": "Player A",
+                "player_id": "a",
+                "team": "AAA",
+                "opponent": "BBB",
+                "game_date": pd.Timestamp("2025-04-01"),
+                "rest_days": 3,
+                "park_factor": 1.0,
+                "stat_id": "hits_allowed",
+                "line": 6.5,
+                "play": "over",
+                "prob": 0.57,
+                "ev": 0.16,
+                "payout": 1.88,
+            },
+            {
+                "player": "Player A",
+                "player_id": "a",
+                "team": "AAA",
+                "opponent": "BBB",
+                "game_date": pd.Timestamp("2025-04-01"),
+                "rest_days": 3,
+                "park_factor": 1.0,
+                "stat_id": "earned_runs",
+                "line": 2.5,
+                "play": "under",
+                "prob": 0.56,
+                "ev": 0.14,
+                "payout": 1.92,
+            },
+            {
+                "player": "Player B",
+                "player_id": "b",
+                "team": "CCC",
+                "opponent": "DDD",
+                "game_date": pd.Timestamp("2025-04-01"),
+                "rest_days": 4,
+                "park_factor": 0.95,
+                "stat_id": "strikeouts",
+                "line": 4.5,
+                "play": "under",
+                "prob": 0.55,
+                "ev": 0.12,
+                "payout": 2.0,
+            },
+        ]
+    )
+
+    slips = generate_slips(df, slip_size=5, payout_table={5: 20.0})
+
+    assert slips == []
+
+
 def test_prepare_long_df_preserves_legacy_context_fields() -> None:
     results = pd.DataFrame(
         [
@@ -144,3 +230,67 @@ def test_prepare_long_df_preserves_legacy_context_fields() -> None:
     assert list(long_df["game_date"]) == [pd.Timestamp("2025-04-01")] * 2
     assert list(long_df["rest_days"]) == [3, 3]
     assert list(long_df["park_factor"]) == [1.1, 1.1]
+
+
+def test_prepare_long_df_preserves_non_strikeout_stat_identity() -> None:
+    results = pd.DataFrame(
+        [
+            {
+                "player": "Player A",
+                "pitcher_id": "a",
+                "pitcher_team": "AAA",
+                "stat_id": "outs_recorded",
+                "upcoming_opponent": "BBB",
+                "upcoming_game_date": pd.Timestamp("2025-04-01"),
+                "upcoming_rest_days": 3,
+                "upcoming_park_factor_outs": 0.97,
+                "outs_line": 17.5,
+                "predicted_outs_recorded": 14.2,
+                "prob_over": 0.35,
+                "prob_under": 0.65,
+                "ev_over": -0.1,
+                "ev_under": 0.18,
+                "over_decimal_price": 1.9,
+                "under_decimal_price": 1.95,
+            },
+            {
+                "player": "Player B",
+                "pitcher_id": "b",
+                "pitcher_team": "CCC",
+                "stat_id": "bb_allowed",
+                "upcoming_opponent": "DDD",
+                "upcoming_game_date": pd.Timestamp("2025-04-01"),
+                "upcoming_rest_days": 4,
+                "upcoming_park_factor_bb": 1.03,
+                "bb_line": 1.5,
+                "predicted_bb_allowed": 2.1,
+                "prob_over": 0.72,
+                "prob_under": 0.28,
+                "ev_over": 0.24,
+                "ev_under": -0.2,
+                "over_decimal_price": 1.88,
+                "under_decimal_price": 1.9,
+            },
+        ]
+    )
+
+    long_df = prepare_long_df(results, min_ev=-1.0)
+
+    outs_under = long_df[
+        (long_df["player"] == "Player A") & (long_df["play"] == "under")
+    ].iloc[0]
+    bb_over = long_df[
+        (long_df["player"] == "Player B") & (long_df["play"] == "over")
+    ].iloc[0]
+
+    assert outs_under["stat_id"] == "outs_recorded"
+    assert outs_under["market"] == "outs_recorded"
+    assert float(outs_under["line"]) == 17.5
+    assert float(outs_under["park_factor"]) == 0.97
+    assert float(outs_under["predicted_outs_recorded"]) == 14.2
+
+    assert bb_over["stat_id"] == "bb_allowed"
+    assert bb_over["market"] == "bb_allowed"
+    assert float(bb_over["line"]) == 1.5
+    assert float(bb_over["park_factor"]) == 1.03
+    assert float(bb_over["predicted_bb_allowed"]) == 2.1


### PR DESCRIPTION
## Summary
- harden MLB live proof/debug workflows with explicit verdicts, evidence, and stat-aware confidence gates
- fix live ingestion, mixed-stat normalization, and starter filtering issues uncovered during proof runs
- add readable slip reporting/printing tooling and move implemented plan docs

## Verification
- .venv/bin/ruff check .
- .venv/bin/pytest -q
