### PR TITLE
Fallback to raw starter IDs when CSV is missing

### DIFF
--- a/scripts/generate_pitcher_dataset_from_raw.py
+++ b/scripts/generate_pitcher_dataset_from_raw.py
@@ -57,8 +57,35 @@ def _extract_mlbam_lookup(lookup_df: pd.DataFrame) -> dict[int, int]:
     return resolved
 
 
+def _derive_pitchers_from_raw(raw_df: pd.DataFrame) -> list[tuple[str, int]]:
+    """Derive starter-like pitcher identities directly from raw Statcast rows."""
+    from src.utils.names import from_last_first
+
+    required = {"pitcher", "player_name", "inning"}
+    if not required.issubset(raw_df.columns):
+        return []
+
+    work = raw_df.copy()
+    work["inning"] = pd.to_numeric(work["inning"], errors="coerce")
+    starters = work.loc[work["inning"] == 1, ["pitcher", "player_name"]].dropna()
+    if starters.empty:
+        return []
+
+    starters = starters.drop_duplicates(subset=["pitcher"], keep="first")
+    starters["display_name"] = starters["player_name"].map(from_last_first)
+    starters = starters.loc[starters["display_name"].astype(str).str.strip() != ""]
+    starters = starters.sort_values("display_name", kind="stable")
+    return [
+        (str(row.display_name), int(row.pitcher))
+        for row in starters.itertuples(index=False)
+    ]
+
+
 def load_pitcher_ids(csv_path: str, raw_df: pd.DataFrame) -> list[tuple[str, int]]:
     """Load starter names and MLBAM ids with a Statcast-based fallback."""
+    if not os.path.exists(csv_path):
+        return _derive_pitchers_from_raw(raw_df)
+
     df = pd.read_csv(csv_path)
     lookup = playerid_reverse_lookup(df["IDfg"].tolist(), key_type="fangraphs")
     lookup_map = _extract_mlbam_lookup(lookup)

--- a/scripts/update_pitcher_dataset_from_raw.py
+++ b/scripts/update_pitcher_dataset_from_raw.py
@@ -65,8 +65,35 @@ def _extract_mlbam_lookup(lookup_df: pd.DataFrame) -> dict[int, int]:
     return resolved
 
 
+def _derive_pitchers_from_raw(raw_df: pd.DataFrame) -> list[tuple[str, int]]:
+    """Derive starter-like pitcher identities directly from raw Statcast rows."""
+    from src.utils.names import from_last_first
+
+    required = {"pitcher", "player_name", "inning"}
+    if not required.issubset(raw_df.columns):
+        return []
+
+    work = raw_df.copy()
+    work["inning"] = pd.to_numeric(work["inning"], errors="coerce")
+    starters = work.loc[work["inning"] == 1, ["pitcher", "player_name"]].dropna()
+    if starters.empty:
+        return []
+
+    starters = starters.drop_duplicates(subset=["pitcher"], keep="first")
+    starters["display_name"] = starters["player_name"].map(from_last_first)
+    starters = starters.loc[starters["display_name"].astype(str).str.strip() != ""]
+    starters = starters.sort_values("display_name", kind="stable")
+    return [
+        (str(row.display_name), int(row.pitcher))
+        for row in starters.itertuples(index=False)
+    ]
+
+
 def load_pitcher_ids(starter_csv: str, raw_df: pd.DataFrame) -> list[tuple[str, int]]:
     """Load starter names and MLBAM ids with a Statcast-based fallback."""
+    if not os.path.exists(starter_csv):
+        return _derive_pitchers_from_raw(raw_df)
+
     df = pd.read_csv(starter_csv)
     lookup = playerid_reverse_lookup(df["IDfg"].tolist(), key_type="fangraphs")
     lookup_map = _extract_mlbam_lookup(lookup)

--- a/tests/test_pitcher_id_resolution.py
+++ b/tests/test_pitcher_id_resolution.py
@@ -54,3 +54,61 @@ def test_generate_script_load_pitcher_ids_fallback(monkeypatch) -> None:
 def test_update_script_load_pitcher_ids_fallback(monkeypatch) -> None:
     fixture_path = Path("tests/testdata/top_starters_fixture.csv")
     _assert_resolution(upd_script, fixture_path, monkeypatch)
+
+
+def test_generate_script_load_pitcher_ids_derives_from_raw_when_csv_missing(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(gen_script, "playerid_reverse_lookup", _fake_reverse_lookup)
+    raw_df = pd.DataFrame(
+        {
+            "player_name": [
+                "Cole, Gerrit",
+                "Cole, Gerrit",
+                "Wheeler, Zack",
+                "Hader, Josh",
+            ],
+            "pitcher": [1, 1, 2, 3],
+            "inning": [1, 2, 1, 9],
+            "game_date": [
+                "2026-04-01",
+                "2026-04-01",
+                "2026-04-02",
+                "2026-04-02",
+            ],
+            "game_pk": [100, 100, 200, 200],
+        }
+    )
+
+    resolved = gen_script.load_pitcher_ids("missing.csv", raw_df)
+
+    assert resolved == [("Gerrit Cole", 1), ("Zack Wheeler", 2)]
+
+
+def test_update_script_load_pitcher_ids_derives_from_raw_when_csv_missing(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(upd_script, "playerid_reverse_lookup", _fake_reverse_lookup)
+    raw_df = pd.DataFrame(
+        {
+            "player_name": [
+                "Cole, Gerrit",
+                "Cole, Gerrit",
+                "Wheeler, Zack",
+                "Hader, Josh",
+            ],
+            "pitcher": [1, 1, 2, 3],
+            "inning": [1, 2, 1, 9],
+            "game_date": [
+                "2026-04-01",
+                "2026-04-01",
+                "2026-04-02",
+                "2026-04-02",
+            ],
+            "game_pk": [100, 100, 200, 200],
+        }
+    )
+
+    resolved = upd_script.load_pitcher_ids("missing.csv", raw_df)
+
+    assert resolved == [("Gerrit Cole", 1), ("Zack Wheeler", 2)]


### PR DESCRIPTION
## Summary
- derive starter identities directly from raw Statcast rows when the starter CSV is unavailable
- apply the fallback in both dataset generation/update scripts
- add regression coverage for the missing-CSV path

## Verification
- .venv/bin/ruff check .
- .venv/bin/pytest -q
